### PR TITLE
Improvements to the detection wizard.

### DIFF
--- a/src/main/java/org/mastodon/detection/DetectionUtil.java
+++ b/src/main/java/org/mastodon/detection/DetectionUtil.java
@@ -1,11 +1,13 @@
 package org.mastodon.detection;
 
+import static org.mastodon.detection.DetectorKeys.DEFAULT_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_RADIUS;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_ROI;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_SETUP_ID;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_THRESHOLD;
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
@@ -366,6 +368,7 @@ public class DetectionUtil
 		settings.put( KEY_RADIUS, DEFAULT_RADIUS );
 		settings.put( KEY_THRESHOLD, DEFAULT_THRESHOLD );
 		settings.put( KEY_ROI, DEFAULT_ROI );
+		settings.put( KEY_ADD_BEHAVIOR, DEFAULT_ADD_BEHAVIOR );
 		return settings;
 	}
 
@@ -395,6 +398,7 @@ public class DetectionUtil
 		ok = ok & checkParameter( settings, KEY_MAX_TIMEPOINT, Integer.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_RADIUS, Double.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_THRESHOLD, Double.class, errorHolder );
+//		ok = ok & checkParameter( settings, KEY_ADD_BEHAVIOR, String.class, errorHolder );
 
 		// Check key presence.
 		final List< String > mandatoryKeys = new ArrayList< >();
@@ -404,6 +408,7 @@ public class DetectionUtil
 		mandatoryKeys.add( KEY_RADIUS );
 		mandatoryKeys.add( KEY_THRESHOLD );
 		final List< String > optionalKeys = new ArrayList< >();
+		optionalKeys.add( KEY_ADD_BEHAVIOR );
 		optionalKeys.add( KEY_ROI );
 		ok = ok & checkMapKeys( settings, mandatoryKeys, optionalKeys, errorHolder );
 

--- a/src/main/java/org/mastodon/detection/DetectorKeys.java
+++ b/src/main/java/org/mastodon/detection/DetectorKeys.java
@@ -77,6 +77,20 @@ public class DetectorKeys
 	 */
 	public static final Interval DEFAULT_ROI = null;
 
+	/**
+	 * Key for the parameter specifying what to do when adding a detection to a
+	 * model that contains an existing detection in the vicinity of the new one.
+	 * Expected values are {@link String}s defining a behavior that can be
+	 * interpreted by the detector implementation. A <code>null</code> value is
+	 * acceptable and will results in picking a default behavior.
+	 */
+	public static final String KEY_ADD_BEHAVIOR = "ADD_BEHAVIOR";
+
+	/**
+	 * Default value for the {@link #KEY_ADD_BEHAVIOR} parameter.
+	 */
+	public static final String DEFAULT_ADD_BEHAVIOR = null;
+
 	private DetectorKeys()
 	{}
 }

--- a/src/main/java/org/mastodon/detection/DoGDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/DoGDetectorOp.java
@@ -39,7 +39,7 @@ import net.imglib2.view.Views;
  * @author Jean-Yves Tinevez
  */
 @Plugin( type = DetectorOp.class )
-public class DogDetectorOp
+public class DoGDetectorOp
 		extends AbstractDetectorOp
 		implements DetectorOp, Benchmark
 {

--- a/src/main/java/org/mastodon/detection/LoGDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/LoGDetectorOp.java
@@ -6,7 +6,7 @@ import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
 import static org.mastodon.detection.DetectorKeys.KEY_ROI;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
 import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
-import static org.mastodon.detection.DogDetectorOp.MIN_SPOT_PIXEL_SIZE;
+import static org.mastodon.detection.DoGDetectorOp.MIN_SPOT_PIXEL_SIZE;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/mastodon/detection/mamut/AbstractSpotDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/mamut/AbstractSpotDetectorOp.java
@@ -1,7 +1,6 @@
 package org.mastodon.detection.mamut;
 
 import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
-import static org.mastodon.detection.DetectorKeys.KEY_ROI;
 
 import java.util.Map;
 
@@ -22,7 +21,6 @@ import org.scijava.thread.ThreadService;
 import bdv.spimdata.SpimDataMinimal;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imagej.ops.special.inplace.Inplaces;
-import net.imglib2.Interval;
 import net.imglib2.algorithm.Benchmark;
 
 public abstract class AbstractSpotDetectorOp extends AbstractUnaryHybridCF< SpimDataMinimal, ModelGraph > implements SpotDetectorOp, Benchmark
@@ -82,8 +80,7 @@ public abstract class AbstractSpotDetectorOp extends AbstractUnaryHybridCF< Spim
 				catch ( final IllegalArgumentException e )
 				{}
 			}
-			final Interval roi = ( Interval ) settings.get( KEY_ROI );
-			detectionCreator = detectionBehavior.getFactory( graph, pm, sti, roi );
+			detectionCreator = detectionBehavior.getFactory( graph, pm, sti );
 		}
 
 		this.detector = ( DetectorOp ) Inplaces.binary1( ops(), cl,

--- a/src/main/java/org/mastodon/detection/mamut/AdvancedDoGDetectorMamut.java
+++ b/src/main/java/org/mastodon/detection/mamut/AdvancedDoGDetectorMamut.java
@@ -1,0 +1,17 @@
+package org.mastodon.detection.mamut;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Difference of Gaussian detector with advanced configuration.
+ *
+ * @author Tobias Pietzsch
+ * @author Jean-Yves Tinevez
+ */
+@Plugin( type = SpotDetectorOp.class, priority = Priority.NORMAL, name = "Advanced DoG detector",
+		description = "<html>"
+				+ "This detector is identifical to the DoG detector, but offers "
+				+ "more configuration options.</html>" )
+public class AdvancedDoGDetectorMamut extends DoGDetectorMamut
+{}

--- a/src/main/java/org/mastodon/detection/mamut/DoGDetectorMamut.java
+++ b/src/main/java/org/mastodon/detection/mamut/DoGDetectorMamut.java
@@ -1,6 +1,6 @@
 package org.mastodon.detection.mamut;
 
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.revised.model.mamut.ModelGraph;
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
@@ -28,7 +28,7 @@ public class DoGDetectorMamut extends AbstractSpotDetectorOp implements SpotDete
 	@Override
 	public void compute( final SpimDataMinimal spimData, final ModelGraph graph )
 	{
-		exec( spimData, graph, DogDetectorOp.class );
+		exec( spimData, graph, DoGDetectorOp.class );
 	}
 
 }

--- a/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
+++ b/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
@@ -1,13 +1,10 @@
 package org.mastodon.detection.mamut;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefList;
+import org.mastodon.collection.RefSet;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionCreatorFactory.DetectionCreator;
-import org.mastodon.kdtree.ClipConvexPolytope;
 import org.mastodon.kdtree.IncrementalNearestNeighborSearch;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.mamut.Model;
@@ -16,11 +13,8 @@ import org.mastodon.revised.model.mamut.Spot;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.spatial.SpatioTemporalIndex;
 
-import net.imglib2.Interval;
 import net.imglib2.RealPoint;
-import net.imglib2.algorithm.kdtree.ConvexPolytope;
-import net.imglib2.algorithm.kdtree.HyperPlane;
-import net.imglib2.neighborsearch.NearestNeighborSearch;
+import net.imglib2.util.LinAlgHelpers;
 
 /**
  * Collection of {@link DetectionCreatorFactory}s suitable to be used with a
@@ -37,33 +31,44 @@ public class MamutDetectionCreatorFactories
 	/**
 	 * Enum for available detection creator behaviours.
 	 * <p>
-	 * {@link DetectionCreatorFactory}s deal with how spots are added to an
-	 * existing model, depending on whether there are existing spots in the
-	 * vicinity.
+	 * {@link DetectionCreatorFactory}s deal with how spots are added to an existing
+	 * model, depending on whether there are existing spots in the vicinity.
 	 *
 	 * @author Jean-Yves Tinevez
 	 */
 	public static enum DetectionBehavior
 	{
+		/**
+		 * Add a new spot even if an existing one is found within its radius.
+		 */
 		ADD( "Add", "Add a new spot even if an existing one is found within its radius." ),
+		/**
+		 * Replace existing spots found within radius of the new one.
+		 */
 		REPLACE( "Replace", "Replace existing spots found within radius of the new one." ),
+		/**
+		 * Do not add a new spot if an existing spot is found within radius.
+		 */
 		DONTADD( "Don't add", "Do not add a new spot if an existing spot is found within radius." ),
-		REMOVEALL( "Remove all", "Remove all spots in ROI prior to detection." );
+		/**
+		 * Remove all spots in time-point prior to detection.
+		 */
+		REMOVEALL( "Remove all", "Remove all spots in time-point prior to detection." );
 
-		private final String name;
+		private final String str;
 
 		private final String info;
 
-		private DetectionBehavior( final String name, final String info )
+		private DetectionBehavior( final String str, final String info )
 		{
-			this.name = name;
+			this.str = str;
 			this.info = info;
 		}
 
 		@Override
 		public String toString()
 		{
-			return name;
+			return str;
 		}
 
 		public String info()
@@ -71,7 +76,7 @@ public class MamutDetectionCreatorFactories
 			return info;
 		}
 
-		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 		{
 			switch ( this )
 			{
@@ -80,7 +85,7 @@ public class MamutDetectionCreatorFactories
 			case DONTADD:
 				return getDontAddDetectionCreatorFactory( graph, pm, sti );
 			case REMOVEALL:
-				return getRemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+				return getRemoveAllDetectionCreatorFactory( graph, pm, sti );
 			case REPLACE:
 				return getReplaceDetectionCreatorFactory( graph, pm, sti );
 			default:
@@ -104,17 +109,17 @@ public class MamutDetectionCreatorFactories
 		return new ReplaceDetectionCreatorFactory( graph, pm, sti );
 	}
 
-	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 	{
-		return new RemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+		return new RemoveAllDetectionCreatorFactory( graph, pm, sti );
 	}
 
 	/**
 	 * Default detection creator suitable to create {@link Spot} vertices in a
-	 * {@link ModelGraph} from the detection returned by the detector. Takes
-	 * care of acquiring the writing lock before adding all the detections of a
-	 * time-point and returning it after. Also resets and feeds the quality
-	 * value to a quality feature.
+	 * {@link ModelGraph} from the detection returned by the detector. Takes care of
+	 * acquiring the writing lock before adding all the detections of a time-point
+	 * and returning it after. Also resets and feeds the quality value to a quality
+	 * feature.
 	 * <p>
 	 * Add spots to the model, regardless of whether there is an existing one
 	 * nearby.
@@ -190,20 +195,17 @@ public class MamutDetectionCreatorFactories
 
 		private final SpatioTemporalIndex< Spot > sti;
 
-		private final Interval roi;
-
-		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 		{
 			this.graph = graph;
 			this.pm = pm;
 			this.sti = sti;
-			this.roi = roi;
 		}
 
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), roi, timepoint );
+			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
@@ -218,16 +220,13 @@ public class MamutDetectionCreatorFactories
 
 		private final int timepoint;
 
-		private final Interval roi;
-
 		private final Spot ref;
 
-		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final Interval roi, final int timepoint )
+		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final int timepoint )
 		{
 			this.graph = graph;
 			this.pm = pm;
 			this.spatialIndex = spatialIndex;
-			this.roi = roi;
 			this.timepoint = timepoint;
 			this.ref = graph.vertexRef();
 		}
@@ -237,44 +236,9 @@ public class MamutDetectionCreatorFactories
 		{
 			graph.getLock().readLock().lock();
 			final RefList< Spot > toRemove = RefCollections.createRefList( graph.vertices() );
-			if ( null == roi )
-			{
-				// Remove all in time-point.
-				for ( final Spot spot : spatialIndex )
-					toRemove.add( spot );
-			}
-			else
-			{
-				/*
-				 * FIXME Does not work. Maybe the normal are not with the right orientation?
-				 */
-
-				// Remove spots in the ROI.
-				final double[][] normals = new double[][] {
-						new double[] { +1., 0., 0. }, // X min plane.
-						new double[] { -1., 0., 0. }, // X max plane.
-						new double[] { 0., +1., 0. }, // Y min plane.
-						new double[] { 0., -1., 0. }, // Y max plane.
-						new double[] { 0., 0., +1. }, // Z min plane.
-						new double[] { 0., 0., -1. } // Z max plane.
-				};
-				final double[] distances = new double[] {
-						roi.min( 0 ),
-						roi.max( 0 ),
-						roi.min( 1 ),
-						roi.max( 1 ),
-						roi.min( 2 ),
-						roi.max( 2 )
-				};
-				final List< HyperPlane > hyperplanes = new ArrayList<>();
-				for ( int i = 0; i < distances.length; i++ )
-					hyperplanes.add( new HyperPlane( normals[ i ], distances[ i ] ) );
-				final ConvexPolytope cp = new ConvexPolytope( hyperplanes );
-				final ClipConvexPolytope< Spot > clip = spatialIndex.getClipConvexPolytope();
-				clip.clip( cp );
-				for ( final Spot spot : clip.getInsideValues() )
-					toRemove.add( spot );
-			}
+			// Remove all in time-point.
+			for ( final Spot spot : spatialIndex )
+				toRemove.add( spot );
 
 			graph.getLock().readLock().unlock();
 			graph.getLock().writeLock().lock();
@@ -315,19 +279,56 @@ public class MamutDetectionCreatorFactories
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getIncrementalNearestNeighborSearch(), timepoint );
+			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
-	private static class ReplaceDetectionCreator extends AddDetectionCreator
+	private static class ReplaceDetectionCreator implements DetectionCreator
 	{
 
 		private final IncrementalNearestNeighborSearch< Spot > search;
 
-		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final IncrementalNearestNeighborSearch< Spot > search, final int timepoint )
+		private double r2max = 0.;
+
+		private final SpatialIndex< Spot > si;
+
+		private final EllipsoidInsideTest test;
+
+		private final RefSet< Spot > toRemove;
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final int timepoint;
+
+		private final Spot ref;
+
+		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > si, final int timepoint )
 		{
-			super( graph, pm, timepoint );
-			this.search = search;
+			this.graph = graph;
+			this.pm = pm;
+			this.si = si;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+			this.search = si.getIncrementalNearestNeighborSearch();
+			this.test = new EllipsoidInsideTest();
+			this.toRemove = RefCollections.createRefSet( graph.vertices() );
+		}
+
+		@Override
+		public void preAddition()
+		{
+			toRemove.clear();
+			// Measure current max bounding sphere radius squared.
+			graph.getLock().readLock().lock();
+			this.r2max = 0.;
+			for ( final Spot spot : si )
+				if ( spot.getBoundingSphereRadiusSquared() > r2max )
+					r2max = spot.getBoundingSphereRadiusSquared();
+
+			graph.getLock().readLock().unlock();
+			graph.getLock().writeLock().lock();
 		}
 
 		@Override
@@ -335,25 +336,27 @@ public class MamutDetectionCreatorFactories
 		{
 			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
 			pm.set( spot, quality );
-
 			search.search( spot );
+			final double lr2 = Math.max( r2max, radius * radius );
 			while ( search.hasNext() )
 			{
-				final Spot next = search.next();
-				if (search.getSquareDistance() > radius * radius )
+				final Spot neigbhor = search.next();
+				if ( neigbhor.equals( spot ) )
+					continue;
+				if ( search.getSquareDistance() > lr2 )
 					break;
-				graph.remove( next );
+				if ( test.areCentersInside( spot, neigbhor ) )
+					toRemove.add( neigbhor );
 			}
+		}
 
-			/*
-			 * TODO This is imperfect. There might be large existing spots that are further
-			 * than the radius and still encompasses the new spot. We do not act on these.
-			 * 
-			 * To fix this, we need to know the max radius in a time-point, and therefore to
-			 * access the BoundingSphereRadiusStatistics. But the instance is part of the
-			 * app model and creating a new one might be costly. Maybe pre-compute the max
-			 * radius of this time point "by hand" in the #preAddition method?
-			 */
+		@Override
+		public void postAddition()
+		{
+			for ( final Spot spot : toRemove )
+				graph.remove( spot );
+
+			graph.getLock().writeLock().unlock();
 		}
 	}
 
@@ -376,46 +379,168 @@ public class MamutDetectionCreatorFactories
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
-	private static class DontAddDetectionCreator extends AddDetectionCreator
+	private static class DontAddDetectionCreator implements DetectionCreator
 	{
 
-		private final NearestNeighborSearch< Spot > search;
+		private final IncrementalNearestNeighborSearch< Spot > search;
 
-		private final RealPoint point;
+		private double r2max;
 
-		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final int timepoint;
+
+		private final SpatialIndex< Spot > si;
+
+		private final EllipsoidInsideTest test;
+
+		private final Spot ref;
+
+		private final RealPoint center;
+
+		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > si, final int timepoint )
 		{
-			super( graph, pm, timepoint );
-			this.search = search;
-			this.point = new RealPoint( 3 );
+			this.graph = graph;
+			this.pm = pm;
+			this.si = si;
+			this.search = si.getIncrementalNearestNeighborSearch();
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+			this.test = new EllipsoidInsideTest();
+			this.center = new RealPoint( 3 );
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().readLock().lock();
+			this.r2max = 0.;
+			for ( final Spot spot : si )
+				if ( spot.getBoundingSphereRadiusSquared() > r2max )
+					r2max = spot.getBoundingSphereRadiusSquared();
+
+			graph.getLock().readLock().unlock();
+			graph.getLock().writeLock().lock();
 		}
 
 		@Override
 		public void createDetection( final double[] pos, final double radius, final double quality )
 		{
-			// Check if there is a close existing spot.
-			point.setPosition( pos );
-			search.search( point );
-			// If yes, don't add.
-			if ( search.getSquareDistance() < radius * radius )
-				return;
-
-			/*
-			 * TODO This is imperfect. There might be large existing spots that are further
-			 * than the radius and still encompasses the new spot. We do not act on these.
-			 * 
-			 * To fix this, we need to know the max radius in a time-point, and therefore to
-			 * access the BoundingSphereRadiusStatistics. But the instance is part of the
-			 * app model and creating a new one might be costly. Maybe pre-compute the max
-			 * radius of this time point "by hand" in the #preAddition method?
-			 */
+			center.setPosition( pos );
+			search.search( center );
+			final double lr2 = Math.max( r2max, radius * radius );
+			while ( search.hasNext() )
+			{
+				final Spot neigbhor = search.next();
+				if ( search.getSquareDistance() > lr2 )
+					break;
+				if ( test.isCenterWithin( neigbhor, pos, radius ) || test.isPointInside( pos, neigbhor ) )
+					return;
+			}
 
 			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
 			pm.set( spot, quality );
 		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
 	}
+
+	/**
+	 * Adapted from ScreenVertexMath.
+	 *
+	 */
+	private static class EllipsoidInsideTest
+	{
+
+		/** Holder for the first spot position. */
+		private final double[] pos1 = new double[ 3 ];
+
+		/** Holder for the second spot position. */
+		private final double[] pos2 = new double[ 3 ];
+
+		/** Holder for the covariance position. */
+		private final double[][] cov = new double[ 3 ][ 3 ];
+
+		/** Used to determines whether a spot contains a position. */
+		private final double[] diff = new double[ 3 ];
+
+		/** Used to determines whether a spot contains a position. */
+		private final double[] vn = new double[ 3 ];
+
+		/** Precision. */
+		private final double[][] P = new double[ 3 ][ 3 ];
+
+		/**
+		 * Returns <code>true</code> if the first spot contains the center of the second
+		 * one, or if the second spot contains the center of the first one.
+		 * 
+		 * @param s1
+		 *            the first spot.
+		 * @param s2
+		 *            the second spot.
+		 * @return <code>true</code> if a center of spot is included in the other spot.
+		 */
+		public boolean areCentersInside( final Spot s1, final Spot s2 )
+		{
+			s2.localize( pos2 );
+			if ( isPointInside( pos2, s1 ) )
+				return true;
+
+			s1.localize( pos2 );
+			return isPointInside( pos2, s2 );
+		}
+
+		/**
+		 * Returns <code>true</code> is the specified position lies inside the spot
+		 * ellipsoid.
+		 * 
+		 * @param pos
+		 *            the position to test.
+		 * @param spot
+		 *            the spot.
+		 * @return <code>true</code> if the position is inside the spot.
+		 */
+		public boolean isPointInside( final double[] pos, final Spot spot )
+		{
+			spot.localize( pos1 );
+			LinAlgHelpers.subtract( pos1, pos, diff );
+			spot.getCovariance( cov );
+			LinAlgHelpers.invertSymmetric3x3( cov, P );
+			LinAlgHelpers.mult( P, diff, vn );
+			final double d2 = LinAlgHelpers.dot( diff, vn );
+			return d2 < 1.;
+		}
+
+		/**
+		 * Returns <code>true</code> if the spot center is within the specified radius
+		 * around the specified position.
+		 * 
+		 * @param spot
+		 *            the spot to test.
+		 * @param pos
+		 *            the position.
+		 * @param radius
+		 *            the radius.
+		 * @return <code>true</code> if the spot center is within <code>radius</code> of
+		 *         <code>pos</code>.
+		 */
+		public boolean isCenterWithin( final Spot spot, final double[] pos, final double radius )
+		{
+			spot.localize( pos1 );
+			return LinAlgHelpers.squareDistance( pos1, pos ) < radius * radius;
+		}
+	}
+
+	private MamutDetectionCreatorFactories()
+	{}
 }

--- a/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
+++ b/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
@@ -1,0 +1,376 @@
+package org.mastodon.detection.mamut;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mastodon.detection.DetectionCreatorFactory;
+import org.mastodon.detection.DetectionCreatorFactory.DetectionCreator;
+import org.mastodon.kdtree.ClipConvexPolytope;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.ModelGraph;
+import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.spatial.SpatialIndex;
+import org.mastodon.spatial.SpatioTemporalIndex;
+
+import net.imglib2.Interval;
+import net.imglib2.RealPoint;
+import net.imglib2.algorithm.kdtree.ConvexPolytope;
+import net.imglib2.algorithm.kdtree.HyperPlane;
+import net.imglib2.neighborsearch.NearestNeighborSearch;
+
+/**
+ * Collection of {@link DetectionCreatorFactory}s suitable to be used with a
+ * MaMuT {@link Model}.
+ * <p>
+ * The factory instances of this collection implement different behaviors
+ * related to what to do when trying to add a spot near an existing one.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class MamutDetectionCreatorFactories
+{
+
+	/**
+	 * Enum for available detection creator behaviours.
+	 * <p>
+	 * {@link DetectionCreatorFactory}s deal with how spots are added to an
+	 * existing model, depending on whether there are existing spots in the
+	 * vicinity.
+	 *
+	 * @author Jean-Yves Tinevez
+	 */
+	public static enum DetectionBehavior
+	{
+		ADD( "Add spot even if an existing one is found." ),
+		REPLACE( "Replace existing spots found close." ),
+		DONTADD( "Do not add if an existing spot is found close." ),
+		REMOVEALL( "Remove all spots in ROI prior to detection." );
+
+		private final String name;
+
+		private DetectionBehavior( final String name )
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+
+		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		{
+			switch ( this )
+			{
+			case ADD:
+				return getAddDetectionCreatorFactory( graph, pm );
+			case DONTADD:
+				return getDontAddDetectionCreatorFactory( graph, pm, sti );
+			case REMOVEALL:
+				return getRemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+			case REPLACE:
+				return getReplaceDetectionCreatorFactory( graph, pm, sti );
+			default:
+				throw new IllegalArgumentException( "Unknown detection bahaviour: " + this );
+			}
+		}
+	}
+
+	public static final DetectionCreatorFactory getAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm )
+	{
+		return new AddDetectionCreatorFactory( graph, pm );
+	}
+
+	public static final DetectionCreatorFactory getDontAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+	{
+		return new DontAddDetectionCreatorFactory( graph, pm, sti );
+	}
+
+	public static final DetectionCreatorFactory getReplaceDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+	{
+		return new ReplaceDetectionCreatorFactory( graph, pm, sti );
+	}
+
+	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+	{
+		return new RemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+	}
+
+	/**
+	 * Default detection creator suitable to create {@link Spot} vertices in a
+	 * {@link ModelGraph} from the detection returned by the detector. Takes
+	 * care of acquiring the writing lock before adding all the detections of a
+	 * time-point and returning it after. Also resets and feeds the quality
+	 * value to a quality feature.
+	 * <p>
+	 * Add spots to the model, regardless of whether there is an existing one
+	 * nearby.
+	 *
+	 * @author Jean-Yves Tinevez
+	 *
+	 */
+	private static class AddDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		public AddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm )
+		{
+			this.graph = graph;
+			this.pm = pm;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new AddDetectionCreator( graph, pm, timepoint );
+		}
+	}
+
+	private static class AddDetectionCreator implements DetectionCreator
+	{
+
+		protected final Spot ref;
+
+		protected final int timepoint;
+
+		protected final DoublePropertyMap< Spot > pm;
+
+		protected final ModelGraph graph;
+
+		private AddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final int timepoint )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().writeLock().lock();
+		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+	}
+
+	private static final class RemoveAllDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		private final Interval roi;
+
+		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+			this.roi = roi;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), roi, timepoint );
+		}
+	}
+
+	private static class RemoveAllDetectionCreator implements DetectionCreator
+	{
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final SpatialIndex< Spot > spatialIndex;
+
+		private final int timepoint;
+
+		private final Interval roi;
+
+		private final Spot ref;
+
+		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final Interval roi, final int timepoint )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.spatialIndex = spatialIndex;
+			this.roi = roi;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().writeLock().lock();
+			if ( null == roi )
+			{
+				// Remove all in time-point.
+				for ( final Spot spot : spatialIndex )
+					graph.remove( spot );
+			}
+			else
+			{
+				// Remove spots in the ROI.
+				final double[][] normals = new double[][] {
+						new double[] { +1., 0., 0. }, // X min plane.
+						new double[] { -1., 0., 0. }, // X max plane.
+						new double[] { 0., +1., 0. }, // Y min plane.
+						new double[] { 0., -1., 0. }, // Y max plane.
+						new double[] { 0., 0., +1. }, // Z min plane.
+						new double[] { 0., 0., -1. } // Z max plane.
+				};
+				final double[] distances = new double[] {
+						roi.min( 0 ),
+						roi.max( 0 ),
+						roi.min( 1 ),
+						roi.max( 1 ),
+						roi.min( 2 ),
+						roi.max( 2 )
+				};
+				final List< HyperPlane > hyperplanes = new ArrayList<>();
+				for ( int i = 0; i < distances.length; i++ )
+					hyperplanes.add( new HyperPlane( normals[ i ], distances[ i ] ) );
+				final ConvexPolytope cp = new ConvexPolytope( hyperplanes );
+				final ClipConvexPolytope< Spot > clip = spatialIndex.getClipConvexPolytope();
+				clip.clip( cp );
+				for ( final Spot spot : clip.getInsideValues() )
+					graph.remove( spot );
+			}
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
+	}
+
+	private static class ReplaceDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		public ReplaceDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+		}
+	}
+
+	private static class ReplaceDetectionCreator extends AddDetectionCreator
+	{
+
+		private final NearestNeighborSearch< Spot > search;
+
+		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		{
+			super( graph, pm, timepoint );
+			this.search = search;
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+
+			search.search( spot );
+			if ( search.getSquareDistance() < radius * radius )
+				graph.remove( search.getSampler().get() );
+			// Remove the closest one.
+		}
+	}
+
+	private static class DontAddDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		public DontAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+		}
+	}
+
+	private static class DontAddDetectionCreator extends AddDetectionCreator
+	{
+
+		private final NearestNeighborSearch< Spot > search;
+
+		private final RealPoint point;
+
+		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		{
+			super( graph, pm, timepoint );
+			this.search = search;
+			this.point = new RealPoint( 3 );
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			// Check if there is a close existing spot.
+			point.setPosition( pos );
+			search.search( point );
+			// If yes, don't add.
+			if ( search.getSquareDistance() < radius * radius )
+				return;
+
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/Settings.java
+++ b/src/main/java/org/mastodon/trackmate/Settings.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.mastodon.detection.DetectionUtil;
@@ -14,7 +15,17 @@ import bdv.spimdata.SpimDataMinimal;
 public class Settings
 {
 
-	public final Values values = new Values();
+	public final Values values;
+
+	public Settings()
+	{
+		this( new Values() );
+	}
+
+	private Settings( final Values values )
+	{
+		this.values = values;
+	}
 
 	public Settings detector( final Class< ? extends SpotDetectorOp > detector )
 	{
@@ -46,6 +57,16 @@ public class Settings
 		return this;
 	}
 
+	/**
+	 * Returns a copy of this settings instance.
+	 * 
+	 * @return a copy of this settings instance.
+	 */
+	public Settings copy()
+	{
+		return new Settings( this.values.copy() );
+	}
+
 	public static class Values
 	{
 		private SpimDataMinimal spimData = null;
@@ -61,6 +82,17 @@ public class Settings
 		public Class< ? extends SpotDetectorOp > getDetector()
 		{
 			return detector;
+		}
+
+		public Values copy()
+		{
+			final Values v = new Values();
+			v.spimData = spimData;
+			v.detector = detector;
+			v.detectorSettings = new HashMap<>( detectorSettings );
+			v.linker = linker;
+			v.linkerSettings = new HashMap<>( linkerSettings );
+			return v;
 		}
 
 		public Map< String, Object > getDetectorSettings()

--- a/src/main/java/org/mastodon/trackmate/Settings.java
+++ b/src/main/java/org/mastodon/trackmate/Settings.java
@@ -67,6 +67,23 @@ public class Settings
 		return new Settings( this.values.copy() );
 	}
 
+	@Override
+	public String toString()
+	{
+		final StringBuffer str = new StringBuffer( super.toString() + ":\n" );
+		str.append( " - spimData: " + values.spimData + "\n" );
+		str.append( " - detector: " + values.detector + "\n" );
+		str.append( " - detector settings: @" + values.detectorSettings.hashCode() + "\n" );
+		for ( final String key : values.detectorSettings.keySet() )
+			str.append( "    - " + key + " = " + values.detectorSettings.get( key ) + "\n" );
+		str.append( " - linker: " + values.linker + "\n" );
+		str.append( " - linker settings: @" + values.linkerSettings.hashCode() + "\n" );
+		for ( final String key : values.linkerSettings.keySet() )
+			str.append( "    - " + key + " = " + values.linkerSettings.get( key ) + "\n" );
+
+		return str.toString();
+	}
+
 	public static class Values
 	{
 		private SpimDataMinimal spimData = null;

--- a/src/main/java/org/mastodon/trackmate/TrackMate.java
+++ b/src/main/java/org/mastodon/trackmate/TrackMate.java
@@ -2,7 +2,6 @@ package org.mastodon.trackmate;
 
 import java.util.Map;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.mastodon.HasErrorMessage;
 import org.mastodon.detection.mamut.SpotDetectorOp;
 import org.mastodon.graph.algorithm.RootFinder;
@@ -10,7 +9,6 @@ import org.mastodon.linking.mamut.SpotLinkerOp;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
-import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.Cancelable;
 import org.scijava.app.StatusService;
 import org.scijava.command.ContextCommand;
@@ -90,22 +88,6 @@ public class TrackMate extends ContextCommand implements HasErrorMessage
 		}
 
 		/*
-		 * Clear previous content.
-		 */
-
-		final ReentrantReadWriteLock lock = graph.getLock();
-		lock.writeLock().lock();
-		try
-		{
-			for ( final Spot spot : graph.vertices() )
-				graph.remove( spot );
-		}
-		finally
-		{
-			lock.writeLock().unlock();
-		}
-
-		/*
 		 * Exec detection.
 		 */
 
@@ -115,7 +97,8 @@ public class TrackMate extends ContextCommand implements HasErrorMessage
 
 		final SpotDetectorOp detector = ( SpotDetectorOp ) Hybrids.unaryCF( ops, cl,
 				graph, spimData,
-				detectorSettings );
+				detectorSettings,
+				model.getSpatioTemporalIndex() );
 		this.currentOp = detector;
 		log.info( "Detection with " + cl.getSimpleName() + '\n' );
 		detector.compute( spimData, graph );

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import org.mastodon.HasErrorMessage;
 import org.mastodon.detection.DetectionUtil;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.linking.LinkingUtils;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -175,7 +175,7 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 				final int nResolutionLevels = DetectionUtil.getNResolutionLevels( spimData, setup );
 				final int level;
 				if ( resolutionLevel < 0 )
-					level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2., tp, setup );
+					level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2., tp, setup );
 				else
 					level = Math.min( nResolutionLevels - 1, resolutionLevel );
 				final AffineTransform3D transform = DetectionUtil.getTransform( spimData, tp, setup, level );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/DetectionSequence.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/DetectionSequence.java
@@ -1,10 +1,5 @@
 package org.mastodon.trackmate.ui.wizard;
 
-import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
-import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
-import static org.mastodon.detection.DetectorKeys.KEY_ROI;
-import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +92,8 @@ public class DetectionSequence implements WizardSequence
 	private SpotDetectorDescriptor getConfigDescriptor()
 	{
 		final Class< ? extends SpotDetectorOp > detectorClass = trackmate.getSettings().values.getDetector();
+
+
 		final List< String > linkerPanelNames = descriptorProvider.getNames();
 		for ( final String key : linkerPanelNames )
 		{
@@ -109,16 +106,16 @@ public class DetectionSequence implements WizardSequence
 				previousDetectorPanel = detectorConfigDescriptor;
 				if ( detectorConfigDescriptor.getContext() == null )
 					windowManager.getContext().inject( detectorConfigDescriptor );
+
+				/*
+				 * Copy as much settings as we can to the potentially new config descriptor.
+				 */
+				final Map< String, Object > oldSettings = new HashMap<>( trackmate.getSettings().values.getDetectorSettings() );
 				final Map< String, Object > defaultSettings = detectorConfigDescriptor.getDefaultSettings();
-
-				// Pass the old ROI to the new settings.
-				final Map< String, Object > oldSettings = trackmate.getSettings().values.getDetectorSettings();
-				defaultSettings.put( KEY_MAX_TIMEPOINT, oldSettings.get( KEY_MAX_TIMEPOINT ) );
-				defaultSettings.put( KEY_MIN_TIMEPOINT, oldSettings.get( KEY_MIN_TIMEPOINT ) );
-				defaultSettings.put( KEY_ROI, oldSettings.get( KEY_ROI ) );
-				defaultSettings.put( KEY_SETUP_ID, oldSettings.get( KEY_SETUP_ID ) );
-
+				for ( final String skey : defaultSettings.keySet() )
+					defaultSettings.put( skey, oldSettings.get( skey ) );
 				trackmate.getSettings().detectorSettings( defaultSettings );
+
 				detectorConfigDescriptor.setTrackMate( trackmate );
 				detectorConfigDescriptor.setWindowManager( windowManager );
 				detectorConfigDescriptor.getPanelComponent().setSize( chooseDetectorDescriptor.getPanelComponent().getSize() );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardDetectionPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardDetectionPlugin.java
@@ -16,6 +16,8 @@ public class WizardDetectionPlugin extends WizardPlugin
 
 	private static final String[] RUN_WIZARD_KEYS = new String[] { "not mapped" };
 
+	private static final Settings settings = new Settings();
+
 	public WizardDetectionPlugin()
 	{
 		super( RUN_WIZARD, "Detection...", "Plugins > TrackMate", RUN_WIZARD_KEYS );
@@ -32,10 +34,9 @@ public class WizardDetectionPlugin extends WizardPlugin
 		 * work, but requires additional casting when instantiation ops.
 		 */
 		final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getSharedBdvData().getSpimData();
-		final Settings settings = new Settings().spimData( spimData );
+		settings.spimData( spimData );
 		final TrackMate trackmate = new TrackMate( settings, appModel.getModel() );
 		getContext().inject( trackmate );
-
 		return new DetectionSequence( trackmate, windowManager, wizard.getLogService() );
 	}
 }

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardUtils.java
@@ -1,0 +1,154 @@
+package org.mastodon.trackmate.ui.wizard;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.mastodon.adapter.FocusModelAdapter;
+import org.mastodon.adapter.HighlightModelAdapter;
+import org.mastodon.adapter.RefBimap;
+import org.mastodon.adapter.SelectionModelAdapter;
+import org.mastodon.graph.GraphIdBimap;
+import org.mastodon.grouping.GroupManager;
+import org.mastodon.model.DefaultFocusModel;
+import org.mastodon.model.DefaultHighlightModel;
+import org.mastodon.model.DefaultSelectionModel;
+import org.mastodon.revised.bdv.BigDataViewerMamut;
+import org.mastodon.revised.bdv.NavigationActionsMamut;
+import org.mastodon.revised.bdv.SharedBigDataViewerData;
+import org.mastodon.revised.bdv.ViewerFrameMamut;
+import org.mastodon.revised.bdv.ViewerPanelMamut;
+import org.mastodon.revised.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayEdgeWrapper;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayGraphWrapper;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayVertexWrapper;
+import org.mastodon.revised.mamut.KeyConfigContexts;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.BoundingSphereRadiusStatistics;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.ModelGraph;
+import org.mastodon.revised.model.mamut.ModelOverlayProperties;
+import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.revised.ui.keymap.Keymap;
+import org.mastodon.revised.ui.keymap.KeymapManager;
+import org.scijava.Context;
+import org.scijava.log.LogService;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.Behaviours;
+
+import bdv.tools.InitializeViewerState;
+import mpicbg.spim.data.SpimDataException;
+
+/**
+ * A collection of static utilities related to running Msatodon with the wizard
+ * framework in this package.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class WizardUtils
+{
+
+	/**
+	 * The name used as frame title for the detection preview frame created by
+	 * {@link #preview(WindowManager, ViewerFrameMamut, Model, LogService)}
+	 * method.
+	 */
+	public static String PREVIEW_DETECTION_FRAME_NAME = "Preview detection";
+
+	/**
+	 * Creates or shows a BDV window suitable to be used as a preview detection
+	 * frame.
+	 * 
+	 * @param viewFrame
+	 *            the viewer frame, potentially created from a previous call to
+	 *            this method. If <code>null</code> a new one will be created
+	 *            and returned. If not <code>null</code>, the window will be
+	 *            brought up front.
+	 * @param shared
+	 *            the {@link SharedBigDataViewerData} from which the image data
+	 *            to show is taken.
+	 * @param model
+	 *            the model to display in the preview frame. The preview window
+	 *            will be notified of changes in this model, and display them.
+	 * @return a new {@link ViewerFrameMamut} or the non-<code>null</code> one
+	 *         passed in argument.
+	 */
+	public static final ViewerFrameMamut preview( ViewerFrameMamut viewFrame, final SharedBigDataViewerData shared, final Model model )
+	{
+		if ( null == viewFrame || !viewFrame.isShowing() )
+		{
+			final ModelGraph graph = model.getGraph();
+			final GraphIdBimap< Spot, Link > graphIdBimap = model.getGraphIdBimap();
+			final String[] keyConfigContexts = new String[] { KeyConfigContexts.BIGDATAVIEWER };
+			final Keymap keymap = new KeymapManager().getForwardDefaultKeymap();
+
+			final BigDataViewerMamut bdv = new BigDataViewerMamut( shared, "Preview detection", new GroupManager( 0 ).createGroupHandle() );
+			final ViewerPanelMamut viewer = bdv.getViewer();
+			InitializeViewerState.initTransform( viewer );
+			viewFrame = bdv.getViewerFrame();
+
+			final BoundingSphereRadiusStatistics radiusStats = new BoundingSphereRadiusStatistics( model );
+			final OverlayGraphWrapper< Spot, Link > viewGraph = new OverlayGraphWrapper< Spot, Link >(
+					graph,
+					graphIdBimap,
+					model.getSpatioTemporalIndex(),
+					graph.getLock(),
+					new ModelOverlayProperties( graph, radiusStats ) );
+			final RefBimap< Spot, OverlayVertexWrapper< Spot, Link > > vertexMap = viewGraph.getVertexMap();
+			final RefBimap< Link, OverlayEdgeWrapper< Spot, Link > > edgeMap = viewGraph.getEdgeMap();
+
+			final DefaultHighlightModel< Spot, Link > highlightModel = new DefaultHighlightModel<>( graphIdBimap );
+			final HighlightModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > highlightModelAdapter =
+					new HighlightModelAdapter<>( highlightModel, vertexMap, edgeMap );
+
+			final DefaultFocusModel< Spot, Link > focusModel = new DefaultFocusModel<>( graphIdBimap );
+			final FocusModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > focusModelAdapter =
+					new FocusModelAdapter<>( focusModel, vertexMap, edgeMap );
+
+			final DefaultSelectionModel< Spot, Link > selectionModel = new DefaultSelectionModel<>( graph, graphIdBimap );
+			final SelectionModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > selectionModelAdapter =
+					new SelectionModelAdapter<>( selectionModel, vertexMap, edgeMap );
+
+			final OverlayGraphRenderer< OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > tracksOverlay = new OverlayGraphRenderer<>(
+					viewGraph,
+					highlightModelAdapter,
+					focusModelAdapter,
+					selectionModelAdapter );
+			viewer.getDisplay().addOverlayRenderer( tracksOverlay );
+			viewer.addRenderTransformListener( tracksOverlay );
+			viewer.addTimePointListener( tracksOverlay );
+			graph.addGraphChangeListener( () -> viewer.getDisplay().repaint() );
+
+			final Actions viewActions = new Actions( keymap.getConfig(), keyConfigContexts );
+			viewActions.install( viewFrame.getKeybindings(), "view" );
+			final Behaviours viewBehaviours = new Behaviours( keymap.getConfig(), keyConfigContexts );
+			viewBehaviours.install( viewFrame.getTriggerbindings(), "view" );
+
+			NavigationActionsMamut.install( viewActions, viewer );
+			viewer.getTransformEventHandler().install( viewBehaviours );
+
+			viewFrame.setVisible( true );
+		}
+		viewFrame.toFront();
+		return viewFrame;
+	}
+
+	private WizardUtils()
+	{}
+
+	public static void main( final String[] args ) throws IOException, SpimDataException
+	{
+		final Context context = new Context();
+		final WindowManager windowManager = new WindowManager( context );
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+		windowManager.getProjectManager().open( project );
+
+		final Model model = new Model();
+		model.getGraph().addVertex().init( 0, new double[] { 50., 50., 50., }, 20. );
+
+		preview( null, windowManager.getAppModel().getSharedBdvData(), model );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
@@ -32,7 +32,7 @@ import javax.swing.SwingUtilities;
 import org.jfree.chart.ChartPanel;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
@@ -137,7 +137,7 @@ public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		final SpimDataMinimal spimData = settings.values.getSpimData();
 		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
-		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final double minSizePixel = DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
 		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
 		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
 		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
@@ -1,0 +1,438 @@
+package org.mastodon.trackmate.ui.wizard.descriptors;
+
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
+import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
+import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
+import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
+import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
+
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.jfree.chart.ChartPanel;
+import org.mastodon.detection.DetectionUtil;
+import org.mastodon.detection.DetectorKeys;
+import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
+import org.mastodon.detection.mamut.SpotDetectorOp;
+import org.mastodon.revised.bdv.SharedBigDataViewerData;
+import org.mastodon.revised.bdv.ViewerFrameMamut;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.trackmate.Settings;
+import org.mastodon.trackmate.TrackMate;
+import org.mastodon.trackmate.ui.wizard.Wizard;
+import org.mastodon.trackmate.ui.wizard.util.WizardUtils;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.util.Affine3DHelpers;
+import mpicbg.spim.data.generic.sequence.BasicMultiResolutionImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import net.imagej.ops.OpService;
+import net.imglib2.realtransform.AffineTransform3D;
+
+@Plugin( type = SpotDetectorDescriptor.class, name = "Advanced DoG detector configuration descriptor" )
+public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
+{
+
+	public static final String IDENTIFIER = "Configure Advanced DoG detector";
+
+	private static final Icon PREVIEW_ICON = new ImageIcon( Wizard.class.getResource( "led-icon-eye-green.png" ) );
+
+	private static final NumberFormat FORMAT = new DecimalFormat( "0.0" );
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private OpService ops;
+
+	private Settings settings;
+
+	private WindowManager windowManager;
+
+	private ChartPanel chartPanel;
+
+	private ViewerFrameMamut viewFrame;
+
+	private final Model localModel;
+
+	public AdvancedDoGDetectorDescriptor()
+	{
+		this.panelIdentifier = IDENTIFIER;
+		this.targetPanel = new AdvancedDoGDetectorPanel();
+		/*
+		 * Use a separate model for the preview. We do not want to touch the
+		 * existing model.
+		 */
+		this.localModel = new Model();
+	}
+
+	/**
+	 * Update the settings field of this descriptor with the values set on the
+	 * GUI.
+	 */
+	private void grabSettings()
+	{
+		if ( null == settings )
+			return;
+
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
+		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, ( ( DetectionBehavior ) panel.behaviorCB.getSelectedItem() ).name() );
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	@Override
+	public Collection< Class< ? extends SpotDetectorOp > > getTargetClasses()
+	{
+		final Collection b = Collections.unmodifiableCollection( Arrays.asList( new Class[] {
+				AdvancedDoGDetectorMamut.class
+		} ) );
+		final Collection< Class< ? extends SpotDetectorOp > > a = b;
+		return a;
+	}
+
+	@Override
+	public void aboutToHidePanel()
+	{
+		if ( null != viewFrame )
+			viewFrame.dispose();
+		viewFrame = null;
+
+		grabSettings();
+		final Integer setupID = ( Integer ) settings.values.getDetectorSettings().get( DetectorKeys.KEY_SETUP_ID );
+		final String units = ( null != setupID && null != settings.values.getSpimData() )
+				? settings.values.getSpimData().getSequenceDescription()
+						.getViewSetups().get( setupID ).getVoxelSize().unit()
+				: "pixels";
+
+		final SpimDataMinimal spimData = settings.values.getSpimData();
+		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
+		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
+		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
+		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );
+		final AffineTransform3D transform = DetectionUtil.getTransform( spimData, timepoint, setupID, level );
+
+		final double sx = Affine3DHelpers.extractScale( mipmapTransform, 0 );
+		final double sy = Affine3DHelpers.extractScale( mipmapTransform, 1 );
+		final double sz = Affine3DHelpers.extractScale( mipmapTransform, 2 );
+
+		final double px = Affine3DHelpers.extractScale( transform, 0 );
+		final double py = Affine3DHelpers.extractScale( transform, 1 );
+		final double pz = Affine3DHelpers.extractScale( transform, 2 );
+
+		final double rx = radius / px;
+		final double ry = radius / py;
+		final double rz = radius / pz;
+
+		log.info( "Configured detector with parameters:\n" );
+		log.info( String.format( "  - spot radius: %.1f %s\n", radius, units ) );
+		log.info( String.format( "  - quality threshold: %.1f\n", ( double ) settings.values.getDetectorSettings().get( KEY_THRESHOLD ) ) );
+		final SequenceDescriptionMinimal seq = spimData.getSequenceDescription();
+		if ( seq.getImgLoader() instanceof BasicMultiResolutionImgLoader )
+		{
+			log.info( String.format( "  - will operate on resolution level %d (%.0f x %.0f x %.0f)\n", level, sx, sy, sz ) );
+			log.info( String.format( "  - at this level, radius = %.1f %s corresponds to:\n", radius, units ) );
+		}
+		else
+		{
+			log.info( String.format( "  - equivalent radius = %.1f %s in pixels:\n", radius, units ) );
+		}
+		log.info( String.format( "      - %.1f pixels in X.\n", rx ) );
+		log.info( String.format( "      - %.1f pixels in Y.\n", ry ) );
+		log.info( String.format( "      - %.1f pixels in Z.\n", rz ) );
+
+	}
+
+	private void preview()
+	{
+		if ( null == windowManager )
+			return;
+
+		final SharedBigDataViewerData shared = windowManager.getAppModel().getSharedBdvData();
+		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );
+		final int currentTimepoint = viewFrame.getViewerPanel().getState().getCurrentTimepoint();
+
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		panel.preview.setEnabled( false );
+		new Thread( "DogDetectorPanel preview thread" )
+		{
+			@Override
+			public void run()
+			{
+				try
+				{
+					grabSettings();
+					final boolean ok = WizardUtils.executeDetectionPreview( localModel, settings, ops, currentTimepoint );
+					if ( !ok )
+						return;
+
+					final int nSpots = WizardUtils.countSpotsIn( localModel, currentTimepoint );
+					panel.lblInfo.setText( "Found " + nSpots + " spots in time-point " + currentTimepoint );
+					plotQualityHistogram();
+				}
+				finally
+				{
+					panel.preview.setEnabled( true );
+				}
+			};
+		}.start();
+
+	}
+
+	private void plotQualityHistogram()
+	{
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		if ( null != chartPanel )
+		{
+			panel.remove( chartPanel );
+			panel.repaint();
+		}
+		this.chartPanel = WizardUtils.createQualityHistogram( localModel );
+		if ( null == chartPanel )
+			return;
+
+		final GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridy = 7;
+		gbc.gridx = 0;
+		gbc.gridwidth = 3;
+		gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+		gbc.fill = GridBagConstraints.BOTH;
+		gbc.insets = new Insets( 5, 5, 5, 5 );
+		panel.add( chartPanel, gbc );
+		panel.revalidate();
+	}
+
+	@Override
+	public Map< String, Object > getDefaultSettings()
+	{
+		return DetectionUtil.getDefaultDetectorSettingsMap();
+	}
+
+	@Override
+	public void setTrackMate( final TrackMate trackmate )
+	{
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+
+		this.settings = trackmate.getSettings();
+		if ( null == settings )
+			return;
+
+		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+
+		final double diameter;
+		final Object objRadius = detectorSettings.get( KEY_RADIUS );
+		if ( null == objRadius )
+			diameter = 2. * DetectorKeys.DEFAULT_RADIUS;
+		else
+			diameter = 2. * ( double ) objRadius;
+
+		final double threshold;
+		final Object objThreshold = detectorSettings.get( KEY_THRESHOLD );
+		if ( null == objThreshold )
+			threshold = DetectorKeys.DEFAULT_THRESHOLD;
+		else
+			threshold = ( double ) objThreshold;
+
+
+		DetectionBehavior detectionBehavior = DetectionBehavior.ADD;
+		final String addBehavior = ( String ) detectorSettings.get( KEY_ADD_BEHAVIOR );
+		if ( null != addBehavior )
+		{
+			try
+			{
+				detectionBehavior = MamutDetectionCreatorFactories.DetectionBehavior.valueOf( addBehavior );
+			}
+			catch ( final IllegalArgumentException e )
+			{}
+		}
+		
+		final int setupID = ( int ) settings.values.getDetectorSettings().get( KEY_SETUP_ID );
+		final BasicViewSetup setup = settings.values.getSpimData().getSequenceDescription().getViewSetups().get( setupID );
+
+		panel.diameter.setValue( diameter );
+		panel.threshold.setValue( threshold );
+		panel.lblDiameterUnit.setText( setup.getVoxelSize().unit() );
+		panel.behaviorCB.setSelectedItem( detectionBehavior );
+	}
+
+	@Override
+	public void setWindowManager( final WindowManager windowManager )
+	{
+		this.windowManager = windowManager;
+	}
+
+	private class AdvancedDoGDetectorPanel extends JPanel
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final JFormattedTextField diameter;
+
+		private final JFormattedTextField threshold;
+
+		private final JLabel lblDiameterUnit;
+
+		private final JButton preview;
+
+		private final JLabel lblInfo;
+
+		private final JComboBox< DetectionBehavior > behaviorCB;
+
+		public AdvancedDoGDetectorPanel()
+		{
+			final GridBagLayout layout = new GridBagLayout();
+			layout.columnWidths = new int[] { 80, 80, 40 };
+			layout.columnWeights = new double[] { 0.2, 0.7, 0.1 };
+			layout.rowHeights = new int[] { 26, 0, 0, 0, 0, 50, 26, 26 };
+			layout.rowWeights = new double[] { 1., 0., 0., 0., 0., 0., 0., 1. };
+			setLayout( layout );
+
+			final GridBagConstraints gbc = new GridBagConstraints();
+			gbc.gridy = 0;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+			gbc.fill = GridBagConstraints.HORIZONTAL;
+			gbc.insets = new Insets( 5, 5, 5, 5 );
+
+			final JLabel title = new JLabel( "Configure detector." );
+			title.setFont( getFont().deriveFont( Font.BOLD ) );
+			add( title, gbc );
+
+			// Diameter.
+			final JLabel lblDiameter = new JLabel( "Estimated diameter:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridwidth = 1;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblDiameter, gbc );
+
+			this.diameter = new JFormattedTextField( FORMAT );
+			diameter.setHorizontalAlignment( JLabel.RIGHT );
+			diameter.addFocusListener( new SelectAllOnFocus( diameter ) );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( diameter, gbc );
+
+			lblDiameterUnit = new JLabel();
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.LINE_END;
+			add( lblDiameterUnit, gbc );
+
+			// Threshold.
+			final JLabel lblThreshold = new JLabel( "Quality threshold:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblThreshold, gbc );
+
+			this.threshold = new JFormattedTextField( FORMAT );
+			threshold.setHorizontalAlignment( JLabel.RIGHT );
+			threshold.addFocusListener( new SelectAllOnFocus( threshold ) );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( threshold, gbc );
+
+			// Behavior.
+			final JLabel lblAddBehavior = new JLabel( "Behavior:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblAddBehavior, gbc );
+
+			this.behaviorCB = new JComboBox<>( MamutDetectionCreatorFactories.DetectionBehavior.values() );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( behaviorCB, gbc );
+
+			// Behavior info.
+			final JLabel lblAddBehaviorInfo = new JLabel( "<html>" + ( ( DetectionBehavior ) behaviorCB.getSelectedItem() ).info() + "</html>" );
+			gbc.gridy++;
+			gbc.fill = GridBagConstraints.HORIZONTAL;
+			gbc.anchor = GridBagConstraints.FIRST_LINE_START;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			add( lblAddBehaviorInfo, gbc );
+			
+			// Hook it to changes in the CB.
+			behaviorCB.addItemListener( ( e ) -> lblAddBehaviorInfo.setText( "<html>" + ( ( DetectionBehavior ) behaviorCB.getSelectedItem() ).info() + "</html>" ) );
+
+			// Preview button.
+			preview = new JButton( "Preview", PREVIEW_ICON );
+			preview.addActionListener( ( e ) -> preview() );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			gbc.anchor = GridBagConstraints.EAST;
+			gbc.fill = GridBagConstraints.NONE;
+			add( preview, gbc );
+
+			// Info text.
+			this.lblInfo = new JLabel( "", JLabel.RIGHT );
+			lblInfo.setFont( getFont().deriveFont( getFont().getSize2D() - 2f ) );
+			gbc.gridwidth = 3;
+			gbc.gridy++;
+			gbc.gridx = 0;
+			add( lblInfo, gbc );
+
+			// Quality histogram place holder.
+		}
+	}
+
+	private static class SelectAllOnFocus extends FocusAdapter
+	{
+		private final JFormattedTextField textField;
+
+		public SelectAllOnFocus( final JFormattedTextField textField )
+		{
+			this.textField = textField;
+		}
+
+		@Override
+		public void focusGained( final FocusEvent e )
+		{
+			SwingUtilities.invokeLater( () -> textField.selectAll() );
+		}
+	}
+
+	public static void main( final String[] args )
+	{
+		final AdvancedDoGDetectorDescriptor desc = new AdvancedDoGDetectorDescriptor();
+
+		final JFrame frame = new JFrame( "Test" );
+		frame.getContentPane().add( desc.targetPanel );
+		frame.setSize( 300, 600 );
+		desc.aboutToDisplayPanel();
+		frame.setVisible( true );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
@@ -94,7 +94,7 @@ public class BoundingBoxDescriptor extends WizardPanelDescriptor implements Cont
 		this.targetPanel = new BoundingBoxPanel();
 	}
 
-	private int previousSetupID = -1;
+	private static int previousSetupID = -1;
 
 	@Override
 	public void aboutToDisplayPanel()
@@ -111,60 +111,62 @@ public class BoundingBoxDescriptor extends WizardPanelDescriptor implements Cont
 		final int setupID = ( int ) settings.values.getDetectorSettings().get( KEY_SETUP_ID );
 		if ( setupID != previousSetupID )
 		{
-			// Remove old overlay.
-			if ( boundingBoxEditor != null )
-				boundingBoxEditor.uninstall();
-			viewFrame = null;
-
-			/*
-			 * Change ROI source and overlay.
-			 */
-			roi = getBoundingBoxModel();
-			roi.intervalChangedListeners().add( () -> {
-				panel.boxSelectionPanel.updateSliders( roi.getInterval() );
-				if ( viewFrame != null )
-					viewFrame.getViewerPanel().getDisplay().repaint();
-			} );
-
-			/*
-			 * We also have to recreate the selection panel linked to the new
-			 * ROI.
-			 */
-			panel.boxSelectionPanel = new BoxSelectionPanel( roi, roi.getMaxInterval() );
-
-			/*
-			 * We reset time bounds.
-			 */
-
-			final int nTimepoints = wm.getAppModel().getMaxTimepoint() - wm.getAppModel().getMinTimepoint();
-
-			panel.minT = new BoundedValue( 0, nTimepoints, 0 );
-			final SliderPanel tMinPanel = new SliderPanel( "t min", panel.minT, 1 );
-			tMinPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
-
-			panel.maxT = new BoundedValue( 0, nTimepoints, nTimepoints );
-			final SliderPanel tMaxPanel = new SliderPanel( "t max", panel.maxT, 1 );
-			tMaxPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
-
-			panel.boundsPanel.removeAll();
-			panel.boundsPanel.add( panel.boxSelectionPanel );
-			panel.boundsPanel.add( tMinPanel );
-			panel.boundsPanel.add( tMaxPanel );
-
-			setPanelEnabled( panel.boundsPanel, panel.useRoi.isSelected() );
-			setPanelEnabled( panel.boxModePanel, panel.useRoi.isSelected() );
-
-			panel.boxSelectionPanel.setBoundsInterval( roi.getMaxInterval() );
-			panel.boxSelectionPanel.updateSliders( roi.getInterval() );
-
-			previousSetupID = setupID;
+			settings.values.getDetectorSettings().put( KEY_ROI, null );
+			panel.useRoi.setSelected( false );
 		}
 		else
 		{
-			panel.minT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT ) );
-			panel.maxT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MAX_TIMEPOINT ) );
+			panel.useRoi.setSelected( null != settings.values.getDetectorSettings().get( KEY_ROI ) );
 		}
 
+		// Remove old overlay.
+		if ( boundingBoxEditor != null )
+			boundingBoxEditor.uninstall();
+		viewFrame = null;
+
+		/*
+		 * We force a reset of the ROI source and overlay.
+		 */
+		roi = getBoundingBoxModel();
+		roi.intervalChangedListeners().add( () -> {
+			panel.boxSelectionPanel.updateSliders( roi.getInterval() );
+			if ( viewFrame != null )
+				viewFrame.getViewerPanel().getDisplay().repaint();
+		} );
+
+		/*
+		 * We also have to recreate the selection panel linked to the new ROI.
+		 */
+		panel.boxSelectionPanel = new BoxSelectionPanel( roi, roi.getMaxInterval() );
+
+		/*
+		 * We reset time bounds.
+		 */
+
+		final int nTimepoints = wm.getAppModel().getMaxTimepoint() - wm.getAppModel().getMinTimepoint();
+
+		panel.minT = new BoundedValue( 0, nTimepoints, 0 );
+		final SliderPanel tMinPanel = new SliderPanel( "t min", panel.minT, 1 );
+		tMinPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
+
+		panel.maxT = new BoundedValue( 0, nTimepoints, nTimepoints );
+		final SliderPanel tMaxPanel = new SliderPanel( "t max", panel.maxT, 1 );
+		tMaxPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
+
+		panel.boundsPanel.removeAll();
+		panel.boundsPanel.add( panel.boxSelectionPanel );
+		panel.boundsPanel.add( tMinPanel );
+		panel.boundsPanel.add( tMaxPanel );
+
+		setPanelEnabled( panel.boundsPanel, panel.useRoi.isSelected() );
+		setPanelEnabled( panel.boxModePanel, panel.useRoi.isSelected() );
+
+		panel.boxSelectionPanel.setBoundsInterval( roi.getMaxInterval() );
+		panel.boxSelectionPanel.updateSliders( roi.getInterval() );
+
+		previousSetupID = setupID;
+		panel.minT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT ) );
+		panel.maxT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MAX_TIMEPOINT ) );
 		toggleBoundingBoxVisibility( panel.useRoi.isSelected() );
 	}
 

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -30,7 +30,7 @@ import javax.swing.SwingUtilities;
 import org.jfree.chart.ChartPanel;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
 import org.mastodon.detection.mamut.LoGDetectorMamut;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
@@ -84,7 +84,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 	public DoGDetectorDescriptor()
 	{
 		this.panelIdentifier = IDENTIFIER;
-		this.targetPanel = new DogDetectorPanel();
+		this.targetPanel = new DoGDetectorPanel();
 		/*
 		 * Use a separate model for the preview. We do not want to touch the
 		 * existing model.
@@ -108,7 +108,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		final SpimDataMinimal spimData = settings.values.getSpimData();
 		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
-		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final double minSizePixel = DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
 		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
 		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
 		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );
@@ -154,7 +154,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );
 		final int currentTimepoint = viewFrame.getViewerPanel().getState().getCurrentTimepoint();
 
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		panel.preview.setEnabled( false );
 		new Thread( "DogDetectorPanel preview thread" )
 		{
@@ -183,7 +183,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 	private void plotQualityHistogram()
 	{
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		if ( null != chartPanel )
 		{
 			panel.remove( chartPanel );
@@ -213,7 +213,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		if ( null == settings )
 			return;
 
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
 		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
 		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
@@ -241,7 +241,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void setTrackMate( final TrackMate trackmate )
 	{
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 
 		this.settings = trackmate.getSettings();
 		if ( null == settings )
@@ -277,7 +277,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		this.windowManager = windowManager;
 	}
 
-	private class DogDetectorPanel extends JPanel
+	private class DoGDetectorPanel extends JPanel
 	{
 
 		private static final long serialVersionUID = 1L;
@@ -292,7 +292,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		private final JLabel lblInfo;
 
-		public DogDetectorPanel()
+		public DoGDetectorPanel()
 		{
 			final GridBagLayout layout = new GridBagLayout();
 			layout.columnWidths = new int[] { 80, 80, 40 };

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate.ui.wizard.descriptors;
 
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
@@ -32,6 +33,7 @@ import org.mastodon.detection.DetectorKeys;
 import org.mastodon.detection.DogDetectorOp;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
 import org.mastodon.detection.mamut.LoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
 import org.mastodon.detection.mamut.SpotDetectorOp;
 import org.mastodon.revised.bdv.SharedBigDataViewerData;
 import org.mastodon.revised.bdv.ViewerFrameMamut;
@@ -215,6 +217,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
 		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
 		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, MamutDetectionCreatorFactories.DetectionBehavior.REMOVEALL.name() );
 	}
 
 	@SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -54,7 +54,7 @@ import net.imagej.ops.OpService;
 import net.imglib2.realtransform.AffineTransform3D;
 
 @Plugin( type = SpotDetectorDescriptor.class, name = "DoG detector configuration descriptor" )
-public class DogDetectorDescriptor extends SpotDetectorDescriptor
+public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 {
 
 	public static final String IDENTIFIER = "Configure DoG detector";
@@ -79,7 +79,7 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 
 	private final Model localModel;
 
-	public DogDetectorDescriptor()
+	public DoGDetectorDescriptor()
 	{
 		this.panelIdentifier = IDENTIFIER;
 		this.targetPanel = new DogDetectorPanel();
@@ -93,7 +93,8 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void aboutToHidePanel()
 	{
-		viewFrame.dispose();
+		if ( null != viewFrame )
+			viewFrame.dispose();
 		viewFrame = null;
 
 		grabSettings();
@@ -187,6 +188,8 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 			panel.repaint();
 		}
 		this.chartPanel = WizardUtils.createQualityHistogram( localModel );
+		if ( null == chartPanel )
+			return;
 
 		final GridBagConstraints gbc = new GridBagConstraints();
 		gbc.gridy = 5;

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
@@ -40,7 +40,7 @@ import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.trackmate.Settings;
 import org.mastodon.trackmate.TrackMate;
 import org.mastodon.trackmate.ui.wizard.Wizard;
-import org.mastodon.trackmate.ui.wizard.WizardUtils;
+import org.mastodon.trackmate.ui.wizard.util.WizardUtils;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -144,7 +144,6 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	{
 		if ( null == windowManager )
 			return;
-
 
 		final SharedBigDataViewerData shared = windowManager.getAppModel().getSharedBdvData();
 		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
@@ -93,8 +93,10 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void aboutToHidePanel()
 	{
-		grabSettings();
+		viewFrame.dispose();
+		viewFrame = null;
 
+		grabSettings();
 		final Integer setupID = ( Integer ) settings.values.getDetectorSettings().get( DetectorKeys.KEY_SETUP_ID );
 		final String units = ( null != setupID && null != settings.values.getSpimData() )
 				? settings.values.getSpimData().getSequenceDescription()

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SetupIdDecriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SetupIdDecriptor.java
@@ -1,5 +1,7 @@
 package org.mastodon.trackmate.ui.wizard.descriptors;
 
+import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
+import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
 
 import java.awt.Font;
@@ -105,9 +107,13 @@ public class SetupIdDecriptor extends WizardPanelDescriptor implements ActionLis
 	{
 		final SetupIdConfigPanel panel = ( SetupIdConfigPanel ) targetPanel;
 		final Object obj = panel.comboBox.getSelectedItem();
-		final Integer setupID = idMap.get( obj );
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+		final Integer setupID = idMap.get( obj );
 		detectorSettings.put( KEY_SETUP_ID, setupID );
+		final SpimDataMinimal spimData = settings.values.getSpimData();
+		final int nTimePoints = spimData.getSequenceDescription().getTimePoints().getTimePoints().size();
+		detectorSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( 0 ) );
+		detectorSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( nTimePoints - 1 ) );
 
 		log.log( String.format( "Selected setup ID %d for detection:\n", ( int ) setupID ) );
 		log.log( echoSetupIDInfo( setupID ) );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate.ui.wizard.util;
 
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 
@@ -25,6 +26,7 @@ import org.mastodon.collection.RefList;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
 import org.mastodon.graph.GraphIdBimap;
 import org.mastodon.grouping.GroupManager;
 import org.mastodon.model.DefaultFocusModel;
@@ -183,6 +185,7 @@ public class WizardUtils
 		final Map< String, Object > detectorSettings = localSettings.values.getDetectorSettings();
 		detectorSettings.put( KEY_MIN_TIMEPOINT, currentTimepoint );
 		detectorSettings.put( KEY_MAX_TIMEPOINT, currentTimepoint );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, DetectionBehavior.REMOVEALL.name() );
 
 		/*
 		 * Execute preview.

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
@@ -1,4 +1,4 @@
-package org.mastodon.trackmate.ui.wizard;
+package org.mastodon.trackmate.ui.wizard.util;
 
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
@@ -56,7 +56,6 @@ import org.mastodon.revised.ui.keymap.Keymap;
 import org.mastodon.revised.ui.keymap.KeymapManager;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.trackmate.Settings;
-import org.mastodon.trackmate.ui.wizard.util.HistogramUtil;
 import org.scijava.Context;
 import org.scijava.log.LogService;
 import org.scijava.ui.behaviour.util.Actions;

--- a/src/test/java/org/mastodon/trackmate/detection/DetectionToTextConcurrentExample.java
+++ b/src/test/java/org/mastodon/trackmate/detection/DetectionToTextConcurrentExample.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorOp;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.scijava.Context;
 
 import bdv.spimdata.SpimDataMinimal;
@@ -150,7 +150,7 @@ public class DetectionToTextConcurrentExample
 		detectorSettings1.put( KEY_THRESHOLD, Double.valueOf( 100. ) );
 		detectorSettings1.put( KEY_MIN_TIMEPOINT, t1a );
 		detectorSettings1.put( KEY_MAX_TIMEPOINT, t1b );
-		final DetectorOp detector1 = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector1 = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings1 );
 
 		/*
@@ -159,7 +159,7 @@ public class DetectionToTextConcurrentExample
 		final Map< String, Object > detectorSettings2 = new HashMap<>( detectorSettings1 );
 		detectorSettings2.put( KEY_MIN_TIMEPOINT, t2a );
 		detectorSettings2.put( KEY_MAX_TIMEPOINT, t2b );
-		final DetectorOp detector2 = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector2 = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings2 );
 
 		/*

--- a/src/test/java/org/mastodon/trackmate/detection/DetectionToTextExample.java
+++ b/src/test/java/org/mastodon/trackmate/detection/DetectionToTextExample.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorOp;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.scijava.Context;
 
 import bdv.spimdata.SpimDataMinimal;
@@ -136,7 +136,7 @@ public class DetectionToTextExample
 		detectorSettings.put( KEY_MIN_TIMEPOINT, tps.get( 0 ).getId() );
 		detectorSettings.put( KEY_MAX_TIMEPOINT, tps.get( tps.size() - 1 ).getId() );
 
-		final DetectorOp detector = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings );
 		detector.mutate1( detectionCreator, spimData );
 

--- a/src/test/java/org/mastodon/trackmate/detection/TestDriveAddBehaviorFactories.java
+++ b/src/test/java/org/mastodon/trackmate/detection/TestDriveAddBehaviorFactories.java
@@ -1,0 +1,91 @@
+package org.mastodon.trackmate.detection;
+
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
+import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
+import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.detection.DetectionUtil;
+import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
+import org.mastodon.detection.mamut.DoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.trackmate.Settings;
+import org.mastodon.trackmate.TrackMate;
+import org.scijava.Context;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import mpicbg.spim.data.SpimDataException;
+
+public class TestDriveAddBehaviorFactories
+{
+
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		final Context context = new Context();
+		final WindowManager windowManager = new WindowManager( context );
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+		windowManager.getProjectManager().open( project );
+
+		SpimDataMinimal sd = null;
+		try
+		{
+			sd = new XmlIoSpimDataMinimal().load( bdvFile );
+		}
+		catch ( final SpimDataException e )
+		{
+			e.printStackTrace();
+			return;
+		}
+		final SpimDataMinimal spimData = sd;
+
+		final Map< String, Object > ds = DetectionUtil.getDefaultDetectorSettingsMap();
+		ds.put( KEY_THRESHOLD, 20. );
+		ds.put( KEY_RADIUS, 5. );
+
+		final Settings settings = new Settings()
+				.spimData( spimData )
+				.detector( DoGDetectorMamut.class )
+				.detectorSettings( ds );
+
+		final Model model = windowManager.getAppModel().getModel();
+		final TrackMate trackmate = new TrackMate( settings, model );
+		trackmate.setContext( windowManager.getContext() );
+
+		if ( !trackmate.execDetection() )
+		{
+			System.err.println( "Detection failed:\n" + trackmate.getErrorMessage() );
+			return;
+		}
+		System.out.println( "First detection completed. Found " + model.getGraph().vertices().size() + " spots." );
+		windowManager.createBigDataViewer();
+
+		ds.put( KEY_ADD_BEHAVIOR, DetectionBehavior.DONTADD.name() );
+		ds.put( KEY_RADIUS, 12. );
+		ds.put( KEY_THRESHOLD, 300. );
+		settings.detector( AdvancedDoGDetectorMamut.class );
+		System.out.println( "Second detection round." );
+
+		if ( !trackmate.execDetection() )
+		{
+			System.err.println( "Detection failed:\n" + trackmate.getErrorMessage() );
+			return;
+		}
+		System.out.println( "Second detection completed. Found " + model.getGraph().vertices().size() + " spots." );
+	}
+}


### PR DESCRIPTION
This PR ships several improvements to the detection and how it is processed in the wizard, following discussions with @tpietzsch. Namely:

- The parameters are remembered between plugin runs.
- There is now an `Advanced DoG detector`. 

It is absolutely identical to the normal one, except that it proposes more configuration options. Well, for now, it is just one, namely how we deal with existing spots when we detect new ones. There are 4 options:
- `Add`: we just add the new spots, regardless of the existing ones.
- `Replace`: if we find some spots that are within radius or that contain the center of the new spot, they are removed from the model and the new one is put instead.
- `Don't add`: if we find some spots that are within radius or that contain the center of the new spot, they are left untouched and the new one is not added.
- `Remove all`: all the spots in the time-point are removed prior to new detection. This is the default.

These behaviors were difficult to code (ellipsoid containing a location), but were surprisingly easy to integrate in the design. The detection framework decouples that actual detection step from adding these detections to the model. We use `DetectionCreator` instances to convert `double[]` coordinates into `Spot` that we add to the model. The 4 behaviors mentioned above are just different implementations of the interface.

Future improvements can be specifying what is the resolution level at which to operate instead of determining automatically. But let's wait for the use case to show up.
