### PR TITLE
Semi automatic tracker.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-ui-swing</artifactId>
+		</dependency>
 	</dependencies>
 
 	<mailingLists>

--- a/src/main/java/org/mastodon/detection/DetectionUtil.java
+++ b/src/main/java/org/mastodon/detection/DetectionUtil.java
@@ -1,11 +1,13 @@
 package org.mastodon.detection;
 
+import static org.mastodon.detection.DetectorKeys.DEFAULT_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_RADIUS;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_ROI;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_SETUP_ID;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_THRESHOLD;
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
@@ -366,6 +368,7 @@ public class DetectionUtil
 		settings.put( KEY_RADIUS, DEFAULT_RADIUS );
 		settings.put( KEY_THRESHOLD, DEFAULT_THRESHOLD );
 		settings.put( KEY_ROI, DEFAULT_ROI );
+		settings.put( KEY_ADD_BEHAVIOR, DEFAULT_ADD_BEHAVIOR );
 		return settings;
 	}
 
@@ -395,6 +398,7 @@ public class DetectionUtil
 		ok = ok & checkParameter( settings, KEY_MAX_TIMEPOINT, Integer.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_RADIUS, Double.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_THRESHOLD, Double.class, errorHolder );
+//		ok = ok & checkParameter( settings, KEY_ADD_BEHAVIOR, String.class, errorHolder );
 
 		// Check key presence.
 		final List< String > mandatoryKeys = new ArrayList< >();
@@ -404,6 +408,7 @@ public class DetectionUtil
 		mandatoryKeys.add( KEY_RADIUS );
 		mandatoryKeys.add( KEY_THRESHOLD );
 		final List< String > optionalKeys = new ArrayList< >();
+		optionalKeys.add( KEY_ADD_BEHAVIOR );
 		optionalKeys.add( KEY_ROI );
 		ok = ok & checkMapKeys( settings, mandatoryKeys, optionalKeys, errorHolder );
 

--- a/src/main/java/org/mastodon/detection/DetectorKeys.java
+++ b/src/main/java/org/mastodon/detection/DetectorKeys.java
@@ -77,6 +77,20 @@ public class DetectorKeys
 	 */
 	public static final Interval DEFAULT_ROI = null;
 
+	/**
+	 * Key for the parameter specifying what to do when adding a detection to a
+	 * model that contains an existing detection in the vicinity of the new one.
+	 * Expected values are {@link String}s defining a behavior that can be
+	 * interpreted by the detector implementation. A <code>null</code> value is
+	 * acceptable and will results in picking a default behavior.
+	 */
+	public static final String KEY_ADD_BEHAVIOR = "ADD_BEHAVIOR";
+
+	/**
+	 * Default value for the {@link #KEY_ADD_BEHAVIOR} parameter.
+	 */
+	public static final String DEFAULT_ADD_BEHAVIOR = null;
+
 	private DetectorKeys()
 	{}
 }

--- a/src/main/java/org/mastodon/detection/DoGDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/DoGDetectorOp.java
@@ -39,7 +39,7 @@ import net.imglib2.view.Views;
  * @author Jean-Yves Tinevez
  */
 @Plugin( type = DetectorOp.class )
-public class DogDetectorOp
+public class DoGDetectorOp
 		extends AbstractDetectorOp
 		implements DetectorOp, Benchmark
 {

--- a/src/main/java/org/mastodon/detection/LoGDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/LoGDetectorOp.java
@@ -6,7 +6,7 @@ import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
 import static org.mastodon.detection.DetectorKeys.KEY_ROI;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
 import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
-import static org.mastodon.detection.DogDetectorOp.MIN_SPOT_PIXEL_SIZE;
+import static org.mastodon.detection.DoGDetectorOp.MIN_SPOT_PIXEL_SIZE;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/mastodon/detection/mamut/AbstractSpotDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/mamut/AbstractSpotDetectorOp.java
@@ -1,7 +1,6 @@
 package org.mastodon.detection.mamut;
 
 import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
-import static org.mastodon.detection.DetectorKeys.KEY_ROI;
 
 import java.util.Map;
 
@@ -22,7 +21,6 @@ import org.scijava.thread.ThreadService;
 import bdv.spimdata.SpimDataMinimal;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imagej.ops.special.inplace.Inplaces;
-import net.imglib2.Interval;
 import net.imglib2.algorithm.Benchmark;
 
 public abstract class AbstractSpotDetectorOp extends AbstractUnaryHybridCF< SpimDataMinimal, ModelGraph > implements SpotDetectorOp, Benchmark
@@ -82,8 +80,7 @@ public abstract class AbstractSpotDetectorOp extends AbstractUnaryHybridCF< Spim
 				catch ( final IllegalArgumentException e )
 				{}
 			}
-			final Interval roi = ( Interval ) settings.get( KEY_ROI );
-			detectionCreator = detectionBehavior.getFactory( graph, pm, sti, roi );
+			detectionCreator = detectionBehavior.getFactory( graph, pm, sti );
 		}
 
 		this.detector = ( DetectorOp ) Inplaces.binary1( ops(), cl,

--- a/src/main/java/org/mastodon/detection/mamut/AdvancedDoGDetectorMamut.java
+++ b/src/main/java/org/mastodon/detection/mamut/AdvancedDoGDetectorMamut.java
@@ -1,0 +1,17 @@
+package org.mastodon.detection.mamut;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Difference of Gaussian detector with advanced configuration.
+ *
+ * @author Tobias Pietzsch
+ * @author Jean-Yves Tinevez
+ */
+@Plugin( type = SpotDetectorOp.class, priority = Priority.NORMAL, name = "Advanced DoG detector",
+		description = "<html>"
+				+ "This detector is identifical to the DoG detector, but offers "
+				+ "more configuration options.</html>" )
+public class AdvancedDoGDetectorMamut extends DoGDetectorMamut
+{}

--- a/src/main/java/org/mastodon/detection/mamut/DoGDetectorMamut.java
+++ b/src/main/java/org/mastodon/detection/mamut/DoGDetectorMamut.java
@@ -1,6 +1,6 @@
 package org.mastodon.detection.mamut;
 
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.revised.model.mamut.ModelGraph;
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
@@ -28,7 +28,7 @@ public class DoGDetectorMamut extends AbstractSpotDetectorOp implements SpotDete
 	@Override
 	public void compute( final SpimDataMinimal spimData, final ModelGraph graph )
 	{
-		exec( spimData, graph, DogDetectorOp.class );
+		exec( spimData, graph, DoGDetectorOp.class );
 	}
 
 }

--- a/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
+++ b/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
@@ -1,13 +1,10 @@
 package org.mastodon.detection.mamut;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefList;
+import org.mastodon.collection.RefSet;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionCreatorFactory.DetectionCreator;
-import org.mastodon.kdtree.ClipConvexPolytope;
 import org.mastodon.kdtree.IncrementalNearestNeighborSearch;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.mamut.Model;
@@ -16,11 +13,8 @@ import org.mastodon.revised.model.mamut.Spot;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.spatial.SpatioTemporalIndex;
 
-import net.imglib2.Interval;
 import net.imglib2.RealPoint;
-import net.imglib2.algorithm.kdtree.ConvexPolytope;
-import net.imglib2.algorithm.kdtree.HyperPlane;
-import net.imglib2.neighborsearch.NearestNeighborSearch;
+import net.imglib2.util.LinAlgHelpers;
 
 /**
  * Collection of {@link DetectionCreatorFactory}s suitable to be used with a
@@ -37,33 +31,44 @@ public class MamutDetectionCreatorFactories
 	/**
 	 * Enum for available detection creator behaviours.
 	 * <p>
-	 * {@link DetectionCreatorFactory}s deal with how spots are added to an
-	 * existing model, depending on whether there are existing spots in the
-	 * vicinity.
+	 * {@link DetectionCreatorFactory}s deal with how spots are added to an existing
+	 * model, depending on whether there are existing spots in the vicinity.
 	 *
 	 * @author Jean-Yves Tinevez
 	 */
 	public static enum DetectionBehavior
 	{
+		/**
+		 * Add a new spot even if an existing one is found within its radius.
+		 */
 		ADD( "Add", "Add a new spot even if an existing one is found within its radius." ),
+		/**
+		 * Replace existing spots found within radius of the new one.
+		 */
 		REPLACE( "Replace", "Replace existing spots found within radius of the new one." ),
+		/**
+		 * Do not add a new spot if an existing spot is found within radius.
+		 */
 		DONTADD( "Don't add", "Do not add a new spot if an existing spot is found within radius." ),
-		REMOVEALL( "Remove all", "Remove all spots in ROI prior to detection." );
+		/**
+		 * Remove all spots in time-point prior to detection.
+		 */
+		REMOVEALL( "Remove all", "Remove all spots in time-point prior to detection." );
 
-		private final String name;
+		private final String str;
 
 		private final String info;
 
-		private DetectionBehavior( final String name, final String info )
+		private DetectionBehavior( final String str, final String info )
 		{
-			this.name = name;
+			this.str = str;
 			this.info = info;
 		}
 
 		@Override
 		public String toString()
 		{
-			return name;
+			return str;
 		}
 
 		public String info()
@@ -71,7 +76,7 @@ public class MamutDetectionCreatorFactories
 			return info;
 		}
 
-		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 		{
 			switch ( this )
 			{
@@ -80,7 +85,7 @@ public class MamutDetectionCreatorFactories
 			case DONTADD:
 				return getDontAddDetectionCreatorFactory( graph, pm, sti );
 			case REMOVEALL:
-				return getRemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+				return getRemoveAllDetectionCreatorFactory( graph, pm, sti );
 			case REPLACE:
 				return getReplaceDetectionCreatorFactory( graph, pm, sti );
 			default:
@@ -104,17 +109,17 @@ public class MamutDetectionCreatorFactories
 		return new ReplaceDetectionCreatorFactory( graph, pm, sti );
 	}
 
-	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 	{
-		return new RemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+		return new RemoveAllDetectionCreatorFactory( graph, pm, sti );
 	}
 
 	/**
 	 * Default detection creator suitable to create {@link Spot} vertices in a
-	 * {@link ModelGraph} from the detection returned by the detector. Takes
-	 * care of acquiring the writing lock before adding all the detections of a
-	 * time-point and returning it after. Also resets and feeds the quality
-	 * value to a quality feature.
+	 * {@link ModelGraph} from the detection returned by the detector. Takes care of
+	 * acquiring the writing lock before adding all the detections of a time-point
+	 * and returning it after. Also resets and feeds the quality value to a quality
+	 * feature.
 	 * <p>
 	 * Add spots to the model, regardless of whether there is an existing one
 	 * nearby.
@@ -190,20 +195,17 @@ public class MamutDetectionCreatorFactories
 
 		private final SpatioTemporalIndex< Spot > sti;
 
-		private final Interval roi;
-
-		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
 		{
 			this.graph = graph;
 			this.pm = pm;
 			this.sti = sti;
-			this.roi = roi;
 		}
 
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), roi, timepoint );
+			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
@@ -218,16 +220,13 @@ public class MamutDetectionCreatorFactories
 
 		private final int timepoint;
 
-		private final Interval roi;
-
 		private final Spot ref;
 
-		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final Interval roi, final int timepoint )
+		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final int timepoint )
 		{
 			this.graph = graph;
 			this.pm = pm;
 			this.spatialIndex = spatialIndex;
-			this.roi = roi;
 			this.timepoint = timepoint;
 			this.ref = graph.vertexRef();
 		}
@@ -237,44 +236,9 @@ public class MamutDetectionCreatorFactories
 		{
 			graph.getLock().readLock().lock();
 			final RefList< Spot > toRemove = RefCollections.createRefList( graph.vertices() );
-			if ( null == roi )
-			{
-				// Remove all in time-point.
-				for ( final Spot spot : spatialIndex )
-					toRemove.add( spot );
-			}
-			else
-			{
-				/*
-				 * FIXME Does not work. Maybe the normal are not with the right orientation?
-				 */
-
-				// Remove spots in the ROI.
-				final double[][] normals = new double[][] {
-						new double[] { +1., 0., 0. }, // X min plane.
-						new double[] { -1., 0., 0. }, // X max plane.
-						new double[] { 0., +1., 0. }, // Y min plane.
-						new double[] { 0., -1., 0. }, // Y max plane.
-						new double[] { 0., 0., +1. }, // Z min plane.
-						new double[] { 0., 0., -1. } // Z max plane.
-				};
-				final double[] distances = new double[] {
-						roi.min( 0 ),
-						roi.max( 0 ),
-						roi.min( 1 ),
-						roi.max( 1 ),
-						roi.min( 2 ),
-						roi.max( 2 )
-				};
-				final List< HyperPlane > hyperplanes = new ArrayList<>();
-				for ( int i = 0; i < distances.length; i++ )
-					hyperplanes.add( new HyperPlane( normals[ i ], distances[ i ] ) );
-				final ConvexPolytope cp = new ConvexPolytope( hyperplanes );
-				final ClipConvexPolytope< Spot > clip = spatialIndex.getClipConvexPolytope();
-				clip.clip( cp );
-				for ( final Spot spot : clip.getInsideValues() )
-					toRemove.add( spot );
-			}
+			// Remove all in time-point.
+			for ( final Spot spot : spatialIndex )
+				toRemove.add( spot );
 
 			graph.getLock().readLock().unlock();
 			graph.getLock().writeLock().lock();
@@ -315,19 +279,56 @@ public class MamutDetectionCreatorFactories
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getIncrementalNearestNeighborSearch(), timepoint );
+			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
-	private static class ReplaceDetectionCreator extends AddDetectionCreator
+	private static class ReplaceDetectionCreator implements DetectionCreator
 	{
 
 		private final IncrementalNearestNeighborSearch< Spot > search;
 
-		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final IncrementalNearestNeighborSearch< Spot > search, final int timepoint )
+		private double r2max = 0.;
+
+		private final SpatialIndex< Spot > si;
+
+		private final EllipsoidInsideTest test;
+
+		private final RefSet< Spot > toRemove;
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final int timepoint;
+
+		private final Spot ref;
+
+		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > si, final int timepoint )
 		{
-			super( graph, pm, timepoint );
-			this.search = search;
+			this.graph = graph;
+			this.pm = pm;
+			this.si = si;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+			this.search = si.getIncrementalNearestNeighborSearch();
+			this.test = new EllipsoidInsideTest();
+			this.toRemove = RefCollections.createRefSet( graph.vertices() );
+		}
+
+		@Override
+		public void preAddition()
+		{
+			toRemove.clear();
+			// Measure current max bounding sphere radius squared.
+			graph.getLock().readLock().lock();
+			this.r2max = 0.;
+			for ( final Spot spot : si )
+				if ( spot.getBoundingSphereRadiusSquared() > r2max )
+					r2max = spot.getBoundingSphereRadiusSquared();
+
+			graph.getLock().readLock().unlock();
+			graph.getLock().writeLock().lock();
 		}
 
 		@Override
@@ -335,25 +336,27 @@ public class MamutDetectionCreatorFactories
 		{
 			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
 			pm.set( spot, quality );
-
 			search.search( spot );
+			final double lr2 = Math.max( r2max, radius * radius );
 			while ( search.hasNext() )
 			{
-				final Spot next = search.next();
-				if (search.getSquareDistance() > radius * radius )
+				final Spot neigbhor = search.next();
+				if ( neigbhor.equals( spot ) )
+					continue;
+				if ( search.getSquareDistance() > lr2 )
 					break;
-				graph.remove( next );
+				if ( test.areCentersInside( spot, neigbhor ) )
+					toRemove.add( neigbhor );
 			}
+		}
 
-			/*
-			 * TODO This is imperfect. There might be large existing spots that are further
-			 * than the radius and still encompasses the new spot. We do not act on these.
-			 * 
-			 * To fix this, we need to know the max radius in a time-point, and therefore to
-			 * access the BoundingSphereRadiusStatistics. But the instance is part of the
-			 * app model and creating a new one might be costly. Maybe pre-compute the max
-			 * radius of this time point "by hand" in the #preAddition method?
-			 */
+		@Override
+		public void postAddition()
+		{
+			for ( final Spot spot : toRemove )
+				graph.remove( spot );
+
+			graph.getLock().writeLock().unlock();
 		}
 	}
 
@@ -376,46 +379,168 @@ public class MamutDetectionCreatorFactories
 		@Override
 		public DetectionCreator create( final int timepoint )
 		{
-			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), timepoint );
 		}
 	}
 
-	private static class DontAddDetectionCreator extends AddDetectionCreator
+	private static class DontAddDetectionCreator implements DetectionCreator
 	{
 
-		private final NearestNeighborSearch< Spot > search;
+		private final IncrementalNearestNeighborSearch< Spot > search;
 
-		private final RealPoint point;
+		private double r2max;
 
-		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final int timepoint;
+
+		private final SpatialIndex< Spot > si;
+
+		private final EllipsoidInsideTest test;
+
+		private final Spot ref;
+
+		private final RealPoint center;
+
+		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > si, final int timepoint )
 		{
-			super( graph, pm, timepoint );
-			this.search = search;
-			this.point = new RealPoint( 3 );
+			this.graph = graph;
+			this.pm = pm;
+			this.si = si;
+			this.search = si.getIncrementalNearestNeighborSearch();
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+			this.test = new EllipsoidInsideTest();
+			this.center = new RealPoint( 3 );
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().readLock().lock();
+			this.r2max = 0.;
+			for ( final Spot spot : si )
+				if ( spot.getBoundingSphereRadiusSquared() > r2max )
+					r2max = spot.getBoundingSphereRadiusSquared();
+
+			graph.getLock().readLock().unlock();
+			graph.getLock().writeLock().lock();
 		}
 
 		@Override
 		public void createDetection( final double[] pos, final double radius, final double quality )
 		{
-			// Check if there is a close existing spot.
-			point.setPosition( pos );
-			search.search( point );
-			// If yes, don't add.
-			if ( search.getSquareDistance() < radius * radius )
-				return;
-
-			/*
-			 * TODO This is imperfect. There might be large existing spots that are further
-			 * than the radius and still encompasses the new spot. We do not act on these.
-			 * 
-			 * To fix this, we need to know the max radius in a time-point, and therefore to
-			 * access the BoundingSphereRadiusStatistics. But the instance is part of the
-			 * app model and creating a new one might be costly. Maybe pre-compute the max
-			 * radius of this time point "by hand" in the #preAddition method?
-			 */
+			center.setPosition( pos );
+			search.search( center );
+			final double lr2 = Math.max( r2max, radius * radius );
+			while ( search.hasNext() )
+			{
+				final Spot neigbhor = search.next();
+				if ( search.getSquareDistance() > lr2 )
+					break;
+				if ( test.isCenterWithin( neigbhor, pos, radius ) || test.isPointInside( pos, neigbhor ) )
+					return;
+			}
 
 			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
 			pm.set( spot, quality );
 		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
 	}
+
+	/**
+	 * Adapted from ScreenVertexMath.
+	 *
+	 */
+	private static class EllipsoidInsideTest
+	{
+
+		/** Holder for the first spot position. */
+		private final double[] pos1 = new double[ 3 ];
+
+		/** Holder for the second spot position. */
+		private final double[] pos2 = new double[ 3 ];
+
+		/** Holder for the covariance position. */
+		private final double[][] cov = new double[ 3 ][ 3 ];
+
+		/** Used to determines whether a spot contains a position. */
+		private final double[] diff = new double[ 3 ];
+
+		/** Used to determines whether a spot contains a position. */
+		private final double[] vn = new double[ 3 ];
+
+		/** Precision. */
+		private final double[][] P = new double[ 3 ][ 3 ];
+
+		/**
+		 * Returns <code>true</code> if the first spot contains the center of the second
+		 * one, or if the second spot contains the center of the first one.
+		 * 
+		 * @param s1
+		 *            the first spot.
+		 * @param s2
+		 *            the second spot.
+		 * @return <code>true</code> if a center of spot is included in the other spot.
+		 */
+		public boolean areCentersInside( final Spot s1, final Spot s2 )
+		{
+			s2.localize( pos2 );
+			if ( isPointInside( pos2, s1 ) )
+				return true;
+
+			s1.localize( pos2 );
+			return isPointInside( pos2, s2 );
+		}
+
+		/**
+		 * Returns <code>true</code> is the specified position lies inside the spot
+		 * ellipsoid.
+		 * 
+		 * @param pos
+		 *            the position to test.
+		 * @param spot
+		 *            the spot.
+		 * @return <code>true</code> if the position is inside the spot.
+		 */
+		public boolean isPointInside( final double[] pos, final Spot spot )
+		{
+			spot.localize( pos1 );
+			LinAlgHelpers.subtract( pos1, pos, diff );
+			spot.getCovariance( cov );
+			LinAlgHelpers.invertSymmetric3x3( cov, P );
+			LinAlgHelpers.mult( P, diff, vn );
+			final double d2 = LinAlgHelpers.dot( diff, vn );
+			return d2 < 1.;
+		}
+
+		/**
+		 * Returns <code>true</code> if the spot center is within the specified radius
+		 * around the specified position.
+		 * 
+		 * @param spot
+		 *            the spot to test.
+		 * @param pos
+		 *            the position.
+		 * @param radius
+		 *            the radius.
+		 * @return <code>true</code> if the spot center is within <code>radius</code> of
+		 *         <code>pos</code>.
+		 */
+		public boolean isCenterWithin( final Spot spot, final double[] pos, final double radius )
+		{
+			spot.localize( pos1 );
+			return LinAlgHelpers.squareDistance( pos1, pos ) < radius * radius;
+		}
+	}
+
+	private MamutDetectionCreatorFactories()
+	{}
 }

--- a/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
+++ b/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
@@ -12,9 +12,9 @@ import org.mastodon.revised.model.mamut.ModelGraph;
 import org.mastodon.revised.model.mamut.Spot;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.spatial.SpatioTemporalIndex;
+import org.mastodon.util.EllipsoidInsideTest;
 
 import net.imglib2.RealPoint;
-import net.imglib2.util.LinAlgHelpers;
 
 /**
  * Collection of {@link DetectionCreatorFactory}s suitable to be used with a
@@ -452,92 +452,6 @@ public class MamutDetectionCreatorFactories
 		public void postAddition()
 		{
 			graph.getLock().writeLock().unlock();
-		}
-	}
-
-	/**
-	 * Adapted from ScreenVertexMath.
-	 *
-	 */
-	private static class EllipsoidInsideTest
-	{
-
-		/** Holder for the first spot position. */
-		private final double[] pos1 = new double[ 3 ];
-
-		/** Holder for the second spot position. */
-		private final double[] pos2 = new double[ 3 ];
-
-		/** Holder for the covariance position. */
-		private final double[][] cov = new double[ 3 ][ 3 ];
-
-		/** Used to determines whether a spot contains a position. */
-		private final double[] diff = new double[ 3 ];
-
-		/** Used to determines whether a spot contains a position. */
-		private final double[] vn = new double[ 3 ];
-
-		/** Precision. */
-		private final double[][] P = new double[ 3 ][ 3 ];
-
-		/**
-		 * Returns <code>true</code> if the first spot contains the center of the second
-		 * one, or if the second spot contains the center of the first one.
-		 * 
-		 * @param s1
-		 *            the first spot.
-		 * @param s2
-		 *            the second spot.
-		 * @return <code>true</code> if a center of spot is included in the other spot.
-		 */
-		public boolean areCentersInside( final Spot s1, final Spot s2 )
-		{
-			s2.localize( pos2 );
-			if ( isPointInside( pos2, s1 ) )
-				return true;
-
-			s1.localize( pos2 );
-			return isPointInside( pos2, s2 );
-		}
-
-		/**
-		 * Returns <code>true</code> is the specified position lies inside the spot
-		 * ellipsoid.
-		 * 
-		 * @param pos
-		 *            the position to test.
-		 * @param spot
-		 *            the spot.
-		 * @return <code>true</code> if the position is inside the spot.
-		 */
-		public boolean isPointInside( final double[] pos, final Spot spot )
-		{
-			spot.localize( pos1 );
-			LinAlgHelpers.subtract( pos1, pos, diff );
-			spot.getCovariance( cov );
-			LinAlgHelpers.invertSymmetric3x3( cov, P );
-			LinAlgHelpers.mult( P, diff, vn );
-			final double d2 = LinAlgHelpers.dot( diff, vn );
-			return d2 < 1.;
-		}
-
-		/**
-		 * Returns <code>true</code> if the spot center is within the specified radius
-		 * around the specified position.
-		 * 
-		 * @param spot
-		 *            the spot to test.
-		 * @param pos
-		 *            the position.
-		 * @param radius
-		 *            the radius.
-		 * @return <code>true</code> if the spot center is within <code>radius</code> of
-		 *         <code>pos</code>.
-		 */
-		public boolean isCenterWithin( final Spot spot, final double[] pos, final double radius )
-		{
-			spot.localize( pos1 );
-			return LinAlgHelpers.squareDistance( pos1, pos ) < radius * radius;
 		}
 	}
 

--- a/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
+++ b/src/main/java/org/mastodon/detection/mamut/MamutDetectionCreatorFactories.java
@@ -1,0 +1,376 @@
+package org.mastodon.detection.mamut;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mastodon.detection.DetectionCreatorFactory;
+import org.mastodon.detection.DetectionCreatorFactory.DetectionCreator;
+import org.mastodon.kdtree.ClipConvexPolytope;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.ModelGraph;
+import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.spatial.SpatialIndex;
+import org.mastodon.spatial.SpatioTemporalIndex;
+
+import net.imglib2.Interval;
+import net.imglib2.RealPoint;
+import net.imglib2.algorithm.kdtree.ConvexPolytope;
+import net.imglib2.algorithm.kdtree.HyperPlane;
+import net.imglib2.neighborsearch.NearestNeighborSearch;
+
+/**
+ * Collection of {@link DetectionCreatorFactory}s suitable to be used with a
+ * MaMuT {@link Model}.
+ * <p>
+ * The factory instances of this collection implement different behaviors
+ * related to what to do when trying to add a spot near an existing one.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class MamutDetectionCreatorFactories
+{
+
+	/**
+	 * Enum for available detection creator behaviours.
+	 * <p>
+	 * {@link DetectionCreatorFactory}s deal with how spots are added to an
+	 * existing model, depending on whether there are existing spots in the
+	 * vicinity.
+	 *
+	 * @author Jean-Yves Tinevez
+	 */
+	public static enum DetectionBehavior
+	{
+		ADD( "Add spot even if an existing one is found." ),
+		REPLACE( "Replace existing spots found close." ),
+		DONTADD( "Do not add if an existing spot is found close." ),
+		REMOVEALL( "Remove all spots in ROI prior to detection." );
+
+		private final String name;
+
+		private DetectionBehavior( final String name )
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+
+		public DetectionCreatorFactory getFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		{
+			switch ( this )
+			{
+			case ADD:
+				return getAddDetectionCreatorFactory( graph, pm );
+			case DONTADD:
+				return getDontAddDetectionCreatorFactory( graph, pm, sti );
+			case REMOVEALL:
+				return getRemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+			case REPLACE:
+				return getReplaceDetectionCreatorFactory( graph, pm, sti );
+			default:
+				throw new IllegalArgumentException( "Unknown detection bahaviour: " + this );
+			}
+		}
+	}
+
+	public static final DetectionCreatorFactory getAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm )
+	{
+		return new AddDetectionCreatorFactory( graph, pm );
+	}
+
+	public static final DetectionCreatorFactory getDontAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+	{
+		return new DontAddDetectionCreatorFactory( graph, pm, sti );
+	}
+
+	public static final DetectionCreatorFactory getReplaceDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+	{
+		return new ReplaceDetectionCreatorFactory( graph, pm, sti );
+	}
+
+	public static final DetectionCreatorFactory getRemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+	{
+		return new RemoveAllDetectionCreatorFactory( graph, pm, sti, roi );
+	}
+
+	/**
+	 * Default detection creator suitable to create {@link Spot} vertices in a
+	 * {@link ModelGraph} from the detection returned by the detector. Takes
+	 * care of acquiring the writing lock before adding all the detections of a
+	 * time-point and returning it after. Also resets and feeds the quality
+	 * value to a quality feature.
+	 * <p>
+	 * Add spots to the model, regardless of whether there is an existing one
+	 * nearby.
+	 *
+	 * @author Jean-Yves Tinevez
+	 *
+	 */
+	private static class AddDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		public AddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm )
+		{
+			this.graph = graph;
+			this.pm = pm;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new AddDetectionCreator( graph, pm, timepoint );
+		}
+	}
+
+	private static class AddDetectionCreator implements DetectionCreator
+	{
+
+		protected final Spot ref;
+
+		protected final int timepoint;
+
+		protected final DoublePropertyMap< Spot > pm;
+
+		protected final ModelGraph graph;
+
+		private AddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final int timepoint )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().writeLock().lock();
+		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+	}
+
+	private static final class RemoveAllDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		private final Interval roi;
+
+		public RemoveAllDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti, final Interval roi )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+			this.roi = roi;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new RemoveAllDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ), roi, timepoint );
+		}
+	}
+
+	private static class RemoveAllDetectionCreator implements DetectionCreator
+	{
+
+		private final ModelGraph graph;
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final SpatialIndex< Spot > spatialIndex;
+
+		private final int timepoint;
+
+		private final Interval roi;
+
+		private final Spot ref;
+
+		public RemoveAllDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatialIndex< Spot > spatialIndex, final Interval roi, final int timepoint )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.spatialIndex = spatialIndex;
+			this.roi = roi;
+			this.timepoint = timepoint;
+			this.ref = graph.vertexRef();
+		}
+
+		@Override
+		public void preAddition()
+		{
+			graph.getLock().writeLock().lock();
+			if ( null == roi )
+			{
+				// Remove all in time-point.
+				for ( final Spot spot : spatialIndex )
+					graph.remove( spot );
+			}
+			else
+			{
+				// Remove spots in the ROI.
+				final double[][] normals = new double[][] {
+						new double[] { +1., 0., 0. }, // X min plane.
+						new double[] { -1., 0., 0. }, // X max plane.
+						new double[] { 0., +1., 0. }, // Y min plane.
+						new double[] { 0., -1., 0. }, // Y max plane.
+						new double[] { 0., 0., +1. }, // Z min plane.
+						new double[] { 0., 0., -1. } // Z max plane.
+				};
+				final double[] distances = new double[] {
+						roi.min( 0 ),
+						roi.max( 0 ),
+						roi.min( 1 ),
+						roi.max( 1 ),
+						roi.min( 2 ),
+						roi.max( 2 )
+				};
+				final List< HyperPlane > hyperplanes = new ArrayList<>();
+				for ( int i = 0; i < distances.length; i++ )
+					hyperplanes.add( new HyperPlane( normals[ i ], distances[ i ] ) );
+				final ConvexPolytope cp = new ConvexPolytope( hyperplanes );
+				final ClipConvexPolytope< Spot > clip = spatialIndex.getClipConvexPolytope();
+				clip.clip( cp );
+				for ( final Spot spot : clip.getInsideValues() )
+					graph.remove( spot );
+			}
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+
+		@Override
+		public void postAddition()
+		{
+			graph.getLock().writeLock().unlock();
+		}
+	}
+
+	private static class ReplaceDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		public ReplaceDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new ReplaceDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+		}
+	}
+
+	private static class ReplaceDetectionCreator extends AddDetectionCreator
+	{
+
+		private final NearestNeighborSearch< Spot > search;
+
+		private ReplaceDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		{
+			super( graph, pm, timepoint );
+			this.search = search;
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+
+			search.search( spot );
+			if ( search.getSquareDistance() < radius * radius )
+				graph.remove( search.getSampler().get() );
+			// Remove the closest one.
+		}
+	}
+
+	private static class DontAddDetectionCreatorFactory implements DetectionCreatorFactory
+	{
+
+		private final DoublePropertyMap< Spot > pm;
+
+		private final ModelGraph graph;
+
+		private final SpatioTemporalIndex< Spot > sti;
+
+		public DontAddDetectionCreatorFactory( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final SpatioTemporalIndex< Spot > sti )
+		{
+			this.graph = graph;
+			this.pm = pm;
+			this.sti = sti;
+		}
+
+		@Override
+		public DetectionCreator create( final int timepoint )
+		{
+			return new DontAddDetectionCreator( graph, pm, sti.getSpatialIndex( timepoint ).getNearestNeighborSearch(), timepoint );
+		}
+	}
+
+	private static class DontAddDetectionCreator extends AddDetectionCreator
+	{
+
+		private final NearestNeighborSearch< Spot > search;
+
+		private final RealPoint point;
+
+		private DontAddDetectionCreator( final ModelGraph graph, final DoublePropertyMap< Spot > pm, final NearestNeighborSearch< Spot > search, final int timepoint )
+		{
+			super( graph, pm, timepoint );
+			this.search = search;
+			this.point = new RealPoint( 3 );
+		}
+
+		@Override
+		public void createDetection( final double[] pos, final double radius, final double quality )
+		{
+			// Check if there is a close existing spot.
+			point.setPosition( pos );
+			search.search( point );
+			// If yes, don't add.
+			if ( search.getSquareDistance() < radius * radius )
+				return;
+
+			final Spot spot = graph.addVertex( ref ).init( timepoint, pos, radius );
+			pm.set( spot, quality );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/linking/LinkerKeys.java
+++ b/src/main/java/org/mastodon/linking/LinkerKeys.java
@@ -3,6 +3,8 @@ package org.mastodon.linking;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.mastodon.detection.DetectorKeys;
+
 public class LinkerKeys
 {
 	/**
@@ -190,6 +192,20 @@ public class LinkerKeys
 	public static final String KEY_POSITION_SIGMA = "POSITION_SIGMA";
 
 	public static final double DEFAULT_POSITION_SIGMA = DEFAULT_MAX_SEARCH_RADIUS / 10.;
+
+	/**
+	 * Key for the parameter that specifies whether linking should occur only on the
+	 * content of the selection model. If <code>false</code>, linking will be
+	 * performed on the whole model between the time-points specified by
+	 * {@link DetectorKeys#KEY_MIN_TIMEPOINT} and
+	 * {@link DetectorKeys#KEY_MAX_TIMEPOINT}. Expected values are {@link Boolean}s.
+	 */
+	public static final String KEY_DO_LINK_SELECTION = "DO_LINK_SELECTION";
+
+	/**
+	 * Default value for the {@link #KEY_DO_LINK_SELECTION} parameter.
+	 */
+	public static final boolean DEFAULT_DO_LINK_SELECTION = false;
 
 	private LinkerKeys()
 	{}

--- a/src/main/java/org/mastodon/linking/LinkingUtils.java
+++ b/src/main/java/org/mastodon/linking/LinkingUtils.java
@@ -10,6 +10,7 @@ import static org.mastodon.linking.LinkerKeys.DEFAULT_ALLOW_TRACK_SPLITTING;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_ALTERNATIVE_LINKING_COST_FACTOR;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_BLOCKING_VALUE;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_CUTOFF_PERCENTILE;
+import static org.mastodon.linking.LinkerKeys.DEFAULT_DO_LINK_SELECTION;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_GAP_CLOSING_FEATURE_PENALTIES;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_GAP_CLOSING_MAX_DISTANCE;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_GAP_CLOSING_MAX_FRAME_GAP;
@@ -25,6 +26,7 @@ import static org.mastodon.linking.LinkerKeys.KEY_ALLOW_TRACK_SPLITTING;
 import static org.mastodon.linking.LinkerKeys.KEY_ALTERNATIVE_LINKING_COST_FACTOR;
 import static org.mastodon.linking.LinkerKeys.KEY_BLOCKING_VALUE;
 import static org.mastodon.linking.LinkerKeys.KEY_CUTOFF_PERCENTILE;
+import static org.mastodon.linking.LinkerKeys.KEY_DO_LINK_SELECTION;
 import static org.mastodon.linking.LinkerKeys.KEY_GAP_CLOSING_FEATURE_PENALTIES;
 import static org.mastodon.linking.LinkerKeys.KEY_GAP_CLOSING_MAX_DISTANCE;
 import static org.mastodon.linking.LinkerKeys.KEY_GAP_CLOSING_MAX_FRAME_GAP;
@@ -86,7 +88,7 @@ public class LinkingUtils
 	{
 		final CostFunction< V, V > costFunction;
 		if ( null == featurePenalties || featurePenalties.isEmpty() )
-			costFunction = new SquareDistCostFunction< V >();
+			costFunction = new SquareDistCostFunction< >();
 		else
 			costFunction = new FeaturePenaltiesCostFunction<>( featurePenalties, featureModel, vertexClass );
 		return costFunction;
@@ -124,6 +126,7 @@ public class LinkingUtils
 		final Map< String, Object > settings = new HashMap<>();
 		settings.put( KEY_MIN_TIMEPOINT, DEFAULT_MIN_TIMEPOINT );
 		settings.put( KEY_MAX_TIMEPOINT, DEFAULT_MAX_TIMEPOINT );
+		settings.put( KEY_DO_LINK_SELECTION, DEFAULT_DO_LINK_SELECTION );
 		// Linking
 		settings.put( KEY_LINKING_MAX_DISTANCE, DEFAULT_LINKING_MAX_DISTANCE );
 		settings.put( KEY_LINKING_FEATURE_PENALTIES, new HashMap<>( DEFAULT_LINKING_FEATURE_PENALTIES ) );

--- a/src/main/java/org/mastodon/linking/mamut/KalmanLinkerMamut.java
+++ b/src/main/java/org/mastodon/linking/mamut/KalmanLinkerMamut.java
@@ -4,9 +4,11 @@ import static org.mastodon.detection.DetectorKeys.DEFAULT_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.DEFAULT_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
+import static org.mastodon.linking.LinkerKeys.DEFAULT_DO_LINK_SELECTION;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_GAP_CLOSING_MAX_FRAME_GAP;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_LINKING_MAX_DISTANCE;
 import static org.mastodon.linking.LinkerKeys.DEFAULT_MAX_SEARCH_RADIUS;
+import static org.mastodon.linking.LinkerKeys.KEY_DO_LINK_SELECTION;
 import static org.mastodon.linking.LinkerKeys.KEY_GAP_CLOSING_MAX_FRAME_GAP;
 import static org.mastodon.linking.LinkerKeys.KEY_KALMAN_SEARCH_RADIUS;
 import static org.mastodon.linking.LinkerKeys.KEY_LINKING_MAX_DISTANCE;
@@ -130,15 +132,17 @@ public class KalmanLinkerMamut extends AbstractSpotLinkerOp
 		ok = ok & checkParameter( settings, KEY_GAP_CLOSING_MAX_FRAME_GAP, Integer.class, str );
 		ok = ok & checkParameter( settings, KEY_MIN_TIMEPOINT, Integer.class, str );
 		ok = ok & checkParameter( settings, KEY_MAX_TIMEPOINT, Integer.class, str );
+		ok = ok & checkParameter( settings, KEY_DO_LINK_SELECTION, Boolean.class, str );
 		return ok;
 	}
 
 	public static Map< String, Object > getDefaultSettingsMap()
 	{
-		final Map< String, Object > sm = new HashMap< String, Object >( 3 );
+		final Map< String, Object > sm = new HashMap<>( 6 );
 		sm.put( KEY_KALMAN_SEARCH_RADIUS, DEFAULT_MAX_SEARCH_RADIUS );
 		sm.put( KEY_LINKING_MAX_DISTANCE, DEFAULT_LINKING_MAX_DISTANCE );
 		sm.put( KEY_GAP_CLOSING_MAX_FRAME_GAP, DEFAULT_GAP_CLOSING_MAX_FRAME_GAP );
+		sm.put( KEY_DO_LINK_SELECTION, DEFAULT_DO_LINK_SELECTION );
 		sm.put( KEY_MIN_TIMEPOINT, DEFAULT_MIN_TIMEPOINT );
 		sm.put( KEY_MAX_TIMEPOINT, DEFAULT_MAX_TIMEPOINT );
 		return sm;

--- a/src/main/java/org/mastodon/linking/sequential/lap/SparseLAPFrameToFrameLinker.java
+++ b/src/main/java/org/mastodon/linking/sequential/lap/SparseLAPFrameToFrameLinker.java
@@ -3,6 +3,7 @@ package org.mastodon.linking.sequential.lap;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.linking.LinkerKeys.KEY_ALTERNATIVE_LINKING_COST_FACTOR;
+import static org.mastodon.linking.LinkerKeys.KEY_DO_LINK_SELECTION;
 import static org.mastodon.linking.LinkerKeys.KEY_LINKING_FEATURE_PENALTIES;
 import static org.mastodon.linking.LinkerKeys.KEY_LINKING_MAX_DISTANCE;
 import static org.mastodon.linking.LinkingUtils.checkFeatureMap;
@@ -119,7 +120,7 @@ public class SparseLAPFrameToFrameLinker< V extends HasTimepoint & RealLocalizab
 		final long start = System.currentTimeMillis();
 
 		// Prepare frame pairs in order. For now they are separated by 1.
-		final ArrayList< int[] > framePairs = new ArrayList< int[] >( maxTimepoint - minTimepoint );
+		final ArrayList< int[] > framePairs = new ArrayList< >( maxTimepoint - minTimepoint );
 		for ( int tp = minTimepoint; tp <= maxTimepoint - 1; tp++ )
 		{ // ascending order
 			framePairs.add( new int[] { tp, tp + 1 } );
@@ -176,7 +177,7 @@ public class SparseLAPFrameToFrameLinker< V extends HasTimepoint & RealLocalizab
 								sources, targets, costFunction, costThreshold, alternativeCostFactor, 1d,
 								refcol, refcol,
 								spotComparator, spotComparator );
-						linker = new JaqamanLinker< V, V >( creator, refcol, refcol );
+						linker = new JaqamanLinker< >( creator, refcol, refcol );
 						if ( !linker.checkInput() || !linker.process() )
 						{
 							errorMessage = "Linking frame " + frame0 + " to " + frame1 + ": " + linker.getErrorMessage();
@@ -260,6 +261,8 @@ public class SparseLAPFrameToFrameLinker< V extends HasTimepoint & RealLocalizab
 		boolean ok = true;
 		ok = ok & checkParameter( settings, KEY_MIN_TIMEPOINT, Integer.class, str );
 		ok = ok & checkParameter( settings, KEY_MAX_TIMEPOINT, Integer.class, str );
+		ok = ok & checkParameter( settings, KEY_DO_LINK_SELECTION, Boolean.class, str );
+
 		// Linking
 		ok = ok & checkParameter( settings, KEY_LINKING_MAX_DISTANCE, Double.class, str );
 		ok = ok & checkFeatureMap( settings, KEY_LINKING_FEATURE_PENALTIES, str );
@@ -267,12 +270,12 @@ public class SparseLAPFrameToFrameLinker< V extends HasTimepoint & RealLocalizab
 		ok = ok & checkParameter( settings, KEY_ALTERNATIVE_LINKING_COST_FACTOR, Double.class, str );
 
 		// Check keys
-		final List< String > mandatoryKeys = new ArrayList< String >();
+		final List< String > mandatoryKeys = new ArrayList< >();
 		mandatoryKeys.add( KEY_MIN_TIMEPOINT );
 		mandatoryKeys.add( KEY_MAX_TIMEPOINT );
 		mandatoryKeys.add( KEY_LINKING_MAX_DISTANCE );
 		mandatoryKeys.add( KEY_ALTERNATIVE_LINKING_COST_FACTOR );
-		final List< String > optionalKeys = new ArrayList< String >();
+		final List< String > optionalKeys = new ArrayList< >();
 		optionalKeys.add( KEY_LINKING_FEATURE_PENALTIES );
 		ok = ok & checkMapKeys( settings, mandatoryKeys, optionalKeys, str );
 

--- a/src/main/java/org/mastodon/trackmate/Settings.java
+++ b/src/main/java/org/mastodon/trackmate/Settings.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.mastodon.detection.DetectionUtil;
@@ -14,7 +15,17 @@ import bdv.spimdata.SpimDataMinimal;
 public class Settings
 {
 
-	public final Values values = new Values();
+	public final Values values;
+
+	public Settings()
+	{
+		this( new Values() );
+	}
+
+	private Settings( final Values values )
+	{
+		this.values = values;
+	}
 
 	public Settings detector( final Class< ? extends SpotDetectorOp > detector )
 	{
@@ -46,6 +57,16 @@ public class Settings
 		return this;
 	}
 
+	/**
+	 * Returns a copy of this settings instance.
+	 * 
+	 * @return a copy of this settings instance.
+	 */
+	public Settings copy()
+	{
+		return new Settings( this.values.copy() );
+	}
+
 	public static class Values
 	{
 		private SpimDataMinimal spimData = null;
@@ -61,6 +82,17 @@ public class Settings
 		public Class< ? extends SpotDetectorOp > getDetector()
 		{
 			return detector;
+		}
+
+		public Values copy()
+		{
+			final Values v = new Values();
+			v.spimData = spimData;
+			v.detector = detector;
+			v.detectorSettings = new HashMap<>( detectorSettings );
+			v.linker = linker;
+			v.linkerSettings = new HashMap<>( linkerSettings );
+			return v;
 		}
 
 		public Map< String, Object > getDetectorSettings()

--- a/src/main/java/org/mastodon/trackmate/Settings.java
+++ b/src/main/java/org/mastodon/trackmate/Settings.java
@@ -67,6 +67,23 @@ public class Settings
 		return new Settings( this.values.copy() );
 	}
 
+	@Override
+	public String toString()
+	{
+		final StringBuffer str = new StringBuffer( super.toString() + ":\n" );
+		str.append( " - spimData: " + values.spimData + "\n" );
+		str.append( " - detector: " + values.detector + "\n" );
+		str.append( " - detector settings: @" + values.detectorSettings.hashCode() + "\n" );
+		for ( final String key : values.detectorSettings.keySet() )
+			str.append( "    - " + key + " = " + values.detectorSettings.get( key ) + "\n" );
+		str.append( " - linker: " + values.linker + "\n" );
+		str.append( " - linker settings: @" + values.linkerSettings.hashCode() + "\n" );
+		for ( final String key : values.linkerSettings.keySet() )
+			str.append( "    - " + key + " = " + values.linkerSettings.get( key ) + "\n" );
+
+		return str.toString();
+	}
+
 	public static class Values
 	{
 		private SpimDataMinimal spimData = null;

--- a/src/main/java/org/mastodon/trackmate/TrackMate.java
+++ b/src/main/java/org/mastodon/trackmate/TrackMate.java
@@ -2,7 +2,6 @@ package org.mastodon.trackmate;
 
 import java.util.Map;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.mastodon.HasErrorMessage;
 import org.mastodon.detection.mamut.SpotDetectorOp;
 import org.mastodon.graph.algorithm.RootFinder;
@@ -10,7 +9,6 @@ import org.mastodon.linking.mamut.SpotLinkerOp;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
-import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.Cancelable;
 import org.scijava.app.StatusService;
 import org.scijava.command.ContextCommand;
@@ -90,22 +88,6 @@ public class TrackMate extends ContextCommand implements HasErrorMessage
 		}
 
 		/*
-		 * Clear previous content.
-		 */
-
-		final ReentrantReadWriteLock lock = graph.getLock();
-		lock.writeLock().lock();
-		try
-		{
-			for ( final Spot spot : graph.vertices() )
-				graph.remove( spot );
-		}
-		finally
-		{
-			lock.writeLock().unlock();
-		}
-
-		/*
 		 * Exec detection.
 		 */
 
@@ -115,7 +97,8 @@ public class TrackMate extends ContextCommand implements HasErrorMessage
 
 		final SpotDetectorOp detector = ( SpotDetectorOp ) Hybrids.unaryCF( ops, cl,
 				graph, spimData,
-				detectorSettings );
+				detectorSettings,
+				model.getSpatioTemporalIndex() );
 		this.currentOp = detector;
 		log.info( "Detection with " + cl.getSimpleName() + '\n' );
 		detector.compute( spimData, graph );

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -37,7 +37,7 @@ import org.mastodon.util.EllipsoidInsideTest;
 import org.scijava.Cancelable;
 import org.scijava.ItemIO;
 import org.scijava.log.LogService;
-import org.scijava.log.StderrLogService;
+import org.scijava.log.Logger;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.thread.ThreadService;
@@ -68,8 +68,6 @@ public class SemiAutomaticTracker
 		implements HasErrorMessage, Cancelable
 {
 
-	private final LogService log = new StderrLogService();
-
 	@Parameter
 	private ThreadService threadService;
 
@@ -85,6 +83,12 @@ public class SemiAutomaticTracker
 	@Parameter
 	private SelectionModel< Spot, Link > selectionModel;
 
+	@Parameter( required = false )
+	private Logger log;
+
+	@Parameter
+	private LogService logService;
+
 	@Parameter( type = ItemIO.OUTPUT )
 	protected String errorMessage;
 
@@ -98,6 +102,9 @@ public class SemiAutomaticTracker
 	@Override
 	public void compute( final Collection< Spot > input, final Map< String, Object > settings, final Model model )
 	{
+		if (null == log)
+			log = logService;
+
 		if ( null == input || input.isEmpty() )
 		{
 			log.info( "Spot collection to track is empty. Stopping." );

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -90,6 +90,11 @@ public class SemiAutomaticTracker
 	@Override
 	public void compute( final Collection< Spot > input, final Map< String, Object > settings, final Model model )
 	{
+		if ( null == input || input.isEmpty() )
+		{
+			log.info( "Spot collection to track is empty. Stopping." );
+			return;
+		}
 
 		final ModelGraph graph = model.getGraph();
 		final SpatioTemporalIndex< Spot > spatioTemporalIndex = model.getSpatioTemporalIndex();
@@ -312,7 +317,8 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 				{
 					log.info( "Suitable spot found, but outside the tolerance radius. "
 							+ "Stopping semi-automatic tracking for spot " + first.getLabel() + ". "
-									+ "Refused to link from " + Util.printCoordinates( source ) + " to " + Util.printCoordinates( p3d ) );
+							+ "Refused to link from spot " + source.getLabel() + " @"
+							+ Util.printCoordinates( source ) + " to " + Util.printCoordinates( p3d ) );
 					continue INPUT;
 				}
 

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -31,6 +31,7 @@ import org.mastodon.revised.model.mamut.ModelGraph;
 import org.mastodon.revised.model.mamut.Spot;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.spatial.SpatioTemporalIndex;
+import org.mastodon.util.EllipsoidInsideTest;
 import org.scijava.Cancelable;
 import org.scijava.ItemIO;
 import org.scijava.log.LogService;
@@ -152,6 +153,8 @@ public class SemiAutomaticTracker
 		 */
 
 		final double[][] cov = new double[3][3];
+		final EllipsoidInsideTest test = new EllipsoidInsideTest();
+
 INPUT: 	for ( final Spot first : input )
 		{
 			final int firstTimepoint = first.getTimepoint();
@@ -333,7 +336,7 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 					spatioTemporalIndex.readLock().unlock();
 				}
 
-				if ( target != null && distance < radius )
+				if ( target != null && ( test.isPointInside( pos, target ) || test.isCenterWithin( target, pos, radius ) ) )
 				{
 
 					/*

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import org.mastodon.HasErrorMessage;
 import org.mastodon.detection.DetectionUtil;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.linking.LinkingUtils;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -175,7 +175,7 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 				final int nResolutionLevels = DetectionUtil.getNResolutionLevels( spimData, setup );
 				final int level;
 				if ( resolutionLevel < 0 )
-					level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2., tp, setup );
+					level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2., tp, setup );
 				else
 					level = Math.min( nResolutionLevels - 1, resolutionLevel );
 				final AffineTransform3D transform = DetectionUtil.getTransform( spimData, tp, setup, level );

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTracker.java
@@ -22,6 +22,7 @@ import org.mastodon.HasErrorMessage;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.linking.LinkingUtils;
+import org.mastodon.model.NavigationHandler;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.bdv.overlay.util.JamaEigenvalueDecomposition;
 import org.mastodon.revised.model.feature.Feature;
@@ -76,6 +77,9 @@ public class SemiAutomaticTracker
 
 	@Parameter( type = ItemIO.INPUT )
 	private SpimDataMinimal spimData;
+
+	@Parameter
+	private NavigationHandler< Spot, Link > navigationHandler;
 
 	@Parameter( type = ItemIO.OUTPUT )
 	protected String errorMessage;
@@ -387,6 +391,9 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 						log.info( "Linking spot " + source.getLabel() + " to spot " + target.getLabel() + " with linking cost " + cost + ". "
 								 + Util.printCoordinates( source ) + " -> " + Util.printCoordinates( target ) );
 						linkCostFeature.getPropertyMap().set( edge, cost );
+
+						if ( null != navigationHandler )
+							navigationHandler.notifyNavigateToVertex( target );
 					}
 					else
 					{
@@ -429,6 +436,9 @@ TIME: 		while ( Math.abs( tp - firstTimepoint ) < nTimepoints )
 							+ " " + Util.printCoordinates( source ) + " -> " + Util.printCoordinates( target ) );
 					linkCostFeature.getPropertyMap().set( edge, cost );
 					qualityFeature.getPropertyMap().set( target, quality );
+
+					if ( null != navigationHandler )
+						navigationHandler.notifyNavigateToVertex( target );
 
 					source.refTo( target );
 					graph.releaseRef( eref );

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerConfigPanel.java
@@ -1,0 +1,193 @@
+package org.mastodon.trackmate.semiauto;
+
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+
+public class SemiAutomaticTrackerConfigPanel extends JPanel
+{
+	public SemiAutomaticTrackerConfigPanel()
+	{
+		final GridBagLayout gridBagLayout = new GridBagLayout();
+		gridBagLayout.columnWidths = new int[] { 0, 0, 240, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		gridBagLayout.columnWeights = new double[] { 1.0, 0.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE };
+		setLayout( gridBagLayout );
+
+		final JLabel lblTitle = new JLabel( "Configure semi-automatic tracker." );
+		lblTitle.setFont( lblTitle.getFont().deriveFont( lblTitle.getFont().getSize() + 5f ) );
+		final GridBagConstraints gbc_lblTitle = new GridBagConstraints();
+		gbc_lblTitle.gridwidth = 3;
+		gbc_lblTitle.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblTitle.gridx = 0;
+		gbc_lblTitle.gridy = 0;
+		add( lblTitle, gbc_lblTitle );
+
+		final JLabel lblDetection = new JLabel( "Detection." );
+		lblDetection.setFont( lblDetection.getFont().deriveFont( lblDetection.getFont().getStyle() | Font.BOLD ) );
+		final GridBagConstraints gbc_lblDetection = new GridBagConstraints();
+		gbc_lblDetection.gridwidth = 3;
+		gbc_lblDetection.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblDetection.gridx = 0;
+		gbc_lblDetection.gridy = 1;
+		add( lblDetection, gbc_lblDetection );
+
+		final JLabel lblSetupId = new JLabel( "Setup ID:" );
+		final GridBagConstraints gbc_lblSetupId = new GridBagConstraints();
+		gbc_lblSetupId.anchor = GridBagConstraints.EAST;
+		gbc_lblSetupId.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblSetupId.gridx = 0;
+		gbc_lblSetupId.gridy = 2;
+		add( lblSetupId, gbc_lblSetupId );
+
+		final JComboBox comboBox = new JComboBox();
+		final GridBagConstraints gbc_comboBox = new GridBagConstraints();
+		gbc_comboBox.gridwidth = 2;
+		gbc_comboBox.insets = new Insets( 5, 5, 5, 5 );
+		gbc_comboBox.fill = GridBagConstraints.HORIZONTAL;
+		gbc_comboBox.gridx = 1;
+		gbc_comboBox.gridy = 2;
+		add( comboBox, gbc_comboBox );
+
+		final JLabel lblQualityFactor = new JLabel( "Quality factor:" );
+		final GridBagConstraints gbc_lblQualityFactor = new GridBagConstraints();
+		gbc_lblQualityFactor.anchor = GridBagConstraints.EAST;
+		gbc_lblQualityFactor.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblQualityFactor.gridx = 0;
+		gbc_lblQualityFactor.gridy = 3;
+		add( lblQualityFactor, gbc_lblQualityFactor );
+
+		final JLabel lblDistanceFactor = new JLabel( "Distance factor:" );
+		final GridBagConstraints gbc_lblDistanceFactor = new GridBagConstraints();
+		gbc_lblDistanceFactor.anchor = GridBagConstraints.EAST;
+		gbc_lblDistanceFactor.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblDistanceFactor.gridx = 0;
+		gbc_lblDistanceFactor.gridy = 4;
+		add( lblDistanceFactor, gbc_lblDistanceFactor );
+
+		final JLabel lblNTimepoints = new JLabel( "N time-points:" );
+		final GridBagConstraints gbc_lblNTimepoints = new GridBagConstraints();
+		gbc_lblNTimepoints.anchor = GridBagConstraints.EAST;
+		gbc_lblNTimepoints.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblNTimepoints.gridx = 0;
+		gbc_lblNTimepoints.gridy = 5;
+		add( lblNTimepoints, gbc_lblNTimepoints );
+
+		final JLabel lblTrackingDirection = new JLabel( "Tracking direction." );
+		lblTrackingDirection.setFont( lblTrackingDirection.getFont().deriveFont( lblTrackingDirection.getFont().getStyle() | Font.BOLD ) );
+		final GridBagConstraints gbc_lblTrackingDirection = new GridBagConstraints();
+		gbc_lblTrackingDirection.gridwidth = 3;
+		gbc_lblTrackingDirection.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblTrackingDirection.gridx = 0;
+		gbc_lblTrackingDirection.gridy = 6;
+		add( lblTrackingDirection, gbc_lblTrackingDirection );
+
+		final JPanel panelTrackingDirection = new JPanel();
+		final GridBagConstraints gbc_panelTrackingDirection = new GridBagConstraints();
+		gbc_panelTrackingDirection.insets = new Insets( 5, 5, 5, 5 );
+		gbc_panelTrackingDirection.gridwidth = 3;
+		gbc_panelTrackingDirection.fill = GridBagConstraints.VERTICAL;
+		gbc_panelTrackingDirection.gridx = 0;
+		gbc_panelTrackingDirection.gridy = 7;
+		add( panelTrackingDirection, gbc_panelTrackingDirection );
+
+		final JRadioButton rdbtnForward = new JRadioButton( "Forward in time." );
+		panelTrackingDirection.add( rdbtnForward );
+
+		final JRadioButton rdbtnBackward = new JRadioButton( "Backward in time." );
+		panelTrackingDirection.add( rdbtnBackward );
+
+		final JLabel lblDealWithExisting = new JLabel( "Existing links." );
+		lblDealWithExisting.setFont( lblDealWithExisting.getFont().deriveFont( lblDealWithExisting.getFont().getStyle() | Font.BOLD ) );
+		final GridBagConstraints gbc_lblDealWithExisting = new GridBagConstraints();
+		gbc_lblDealWithExisting.gridwidth = 3;
+		gbc_lblDealWithExisting.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblDealWithExisting.gridx = 0;
+		gbc_lblDealWithExisting.gridy = 8;
+		add( lblDealWithExisting, gbc_lblDealWithExisting );
+
+		final JLabel lblAllowLinkingIf = new JLabel( "Allow linking if target spot has links?" );
+		final GridBagConstraints gbc_lblAllowLinkingIf = new GridBagConstraints();
+		gbc_lblAllowLinkingIf.gridwidth = 3;
+		gbc_lblAllowLinkingIf.anchor = GridBagConstraints.WEST;
+		gbc_lblAllowLinkingIf.fill = GridBagConstraints.VERTICAL;
+		gbc_lblAllowLinkingIf.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblAllowLinkingIf.gridx = 0;
+		gbc_lblAllowLinkingIf.gridy = 9;
+		add( lblAllowLinkingIf, gbc_lblAllowLinkingIf );
+
+		final JCheckBox chckbxLinkIncoming = new JCheckBox( "Link even if target has incoming links." );
+		final GridBagConstraints gbc_chckbxLinkIncoming = new GridBagConstraints();
+		gbc_chckbxLinkIncoming.insets = new Insets( 5, 5, 5, 5 );
+		gbc_chckbxLinkIncoming.anchor = GridBagConstraints.WEST;
+		gbc_chckbxLinkIncoming.gridwidth = 2;
+		gbc_chckbxLinkIncoming.gridx = 1;
+		gbc_chckbxLinkIncoming.gridy = 10;
+		add( chckbxLinkIncoming, gbc_chckbxLinkIncoming );
+
+		final JCheckBox chckbxLinkOutgoing = new JCheckBox( "Link even if target has outgoing links." );
+		final GridBagConstraints gbc_chckbxLinkOutgoing = new GridBagConstraints();
+		gbc_chckbxLinkOutgoing.insets = new Insets( 5, 5, 5, 5 );
+		gbc_chckbxLinkOutgoing.anchor = GridBagConstraints.WEST;
+		gbc_chckbxLinkOutgoing.gridwidth = 2;
+		gbc_chckbxLinkOutgoing.gridx = 1;
+		gbc_chckbxLinkOutgoing.gridy = 11;
+		add( chckbxLinkOutgoing, gbc_chckbxLinkOutgoing );
+
+		final JLabel lblContinueTrackingIf = new JLabel( "Continue tracking if source and target spots are already linked?" );
+		final GridBagConstraints gbc_lblContinueTrackingIf = new GridBagConstraints();
+		gbc_lblContinueTrackingIf.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblContinueTrackingIf.anchor = GridBagConstraints.WEST;
+		gbc_lblContinueTrackingIf.gridwidth = 3;
+		gbc_lblContinueTrackingIf.gridx = 0;
+		gbc_lblContinueTrackingIf.gridy = 12;
+		add( lblContinueTrackingIf, gbc_lblContinueTrackingIf );
+
+		final JCheckBox chckbxContinueTracking = new JCheckBox( "Continue tracking." );
+		final GridBagConstraints gbc_chckbxContinueTracking = new GridBagConstraints();
+		gbc_chckbxContinueTracking.insets = new Insets( 5, 5, 5, 5 );
+		gbc_chckbxContinueTracking.anchor = GridBagConstraints.WEST;
+		gbc_chckbxContinueTracking.gridwidth = 2;
+		gbc_chckbxContinueTracking.gridx = 1;
+		gbc_chckbxContinueTracking.gridy = 13;
+		add( chckbxContinueTracking, gbc_chckbxContinueTracking );
+
+		final JPanel panelButtons = new JPanel();
+		final GridBagConstraints gbc_panelButtons = new GridBagConstraints();
+		gbc_panelButtons.anchor = GridBagConstraints.SOUTH;
+		gbc_panelButtons.gridwidth = 3;
+		gbc_panelButtons.insets = new Insets( 5, 5, 5, 5 );
+		gbc_panelButtons.fill = GridBagConstraints.HORIZONTAL;
+		gbc_panelButtons.gridx = 0;
+		gbc_panelButtons.gridy = 14;
+		add( panelButtons, gbc_panelButtons );
+		panelButtons.setLayout( new BoxLayout( panelButtons, BoxLayout.X_AXIS ) );
+
+		final JButton btnDefaults = new JButton( "Defaults" );
+		panelButtons.add( btnDefaults );
+
+		final Component horizontalGlue = Box.createHorizontalGlue();
+		panelButtons.add( horizontalGlue );
+
+		final JButton btnCancel = new JButton( "Cancel" );
+		panelButtons.add( btnCancel );
+
+		final JButton btnApply = new JButton( "Apply" );
+		panelButtons.add( btnApply );
+	}
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerConfigPanel.java
@@ -10,27 +10,88 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.SwingConstants;
+
+import org.mastodon.trackmate.ui.wizard.util.SetupIDComboBox;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.tools.brightness.SliderPanel;
+import bdv.tools.brightness.SliderPanelDouble;
+import bdv.util.BoundedValue;
+import bdv.util.BoundedValueDouble;
 
 public class SemiAutomaticTrackerConfigPanel extends JPanel
 {
-	public SemiAutomaticTrackerConfigPanel()
+
+	private static final String QUALITY_FACTOR_TOOLTIP = "<html><p width=\"500\">"
+			+ "Parameter that specifies the tolerance on quality for "
+			+ "discovered spots. A target spot may be linked to the source spot only if "
+			+ "the target spot has a quality higher than the source spot quality times "
+			+ "this factor."
+			+ "</p></html>";
+
+	private static final String DISTANCE_FACTOR_TOOLTIP = "<html><p width=\"500\">"
+			+ "Parameter that specifies the tolerance on distance for "
+			+ "discovered spots. A target spot may be linked to the source spot only if "
+			+ " they are not father than the source spot radius times this factor."
+			+ "</p></html>";
+
+	private static final String N_TIMEPOINTS_TOOLTIP = "<html><p width=\"500\">"
+			+ "Parameter specifying how many time-points are processed at "
+			+ "most, from the input source spot. "
+			+ "</p></html>";
+
+	private static final String ALLOW_LINKING_TO_EXISTING_TOOLTIP = "<html><p width=\"500\">"
+			+ "Parameter specifying whether we allow linking to a spot "
+			+ "already existing in the model. "
+			+ "If the best candidate spot is found near a spot already existing in the "
+			+ "model (within radius), semi-automatic tracking will stop, unless this "
+			+ "parameter is checked. In that case the source spot might "
+			+ "be linked to the pre-existing spot, depending on whether it has incoming "
+			+ "or outgoing links already. "
+			+ "</p></html>";
+
+	private static final String ALLOW_LINKING_IF_INCOMING_TOOLTIP = "<html><p width=\"500\"> "
+			+ "Parameter specifying whether we allow linking to spot already "
+			+ "existing in the model if it has already incoming links. "
+			+ "If this parameter is set to <code>true</code>, we allow linking to "
+			+ "existing spots that already have incoming links (more than 0)."
+			+ "</p></html>";
+
+	private static final String ALLOW_LINKING_IF_OUTGOING_TOOLTIP = "<html><p width=\"500\"> "
+			+ "Parameter specifying whether we allow linking to spot already "
+			+ "existing in the model if it has already outgoing links. "
+			+ "If this parameter is set to <code>true</code>, we allow linking to "
+			+ "existing spots that already have outgoing links (more than 0)."
+			+ "</p></html>";
+
+	private static final String CONTINUE_LINKING_TOOLTIP = "<html><p width=\"500\"> "
+			+ "Parameter that specifies whether we continue semi-automatic "
+			+ "tracking even if a link already exists in the model between the source and the "
+			+ "target spots. "
+			+ "</p></html>";
+
+	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData )
 	{
+		final int nTimePoints = ( null == spimData )
+				? 100
+				: spimData.getSequenceDescription().getTimePoints().size();
+
 		final GridBagLayout gridBagLayout = new GridBagLayout();
-		gridBagLayout.columnWidths = new int[] { 0, 0, 240, 0 };
-		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-		gridBagLayout.columnWeights = new double[] { 1.0, 0.0, 1.0, Double.MIN_VALUE };
-		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.columnWidths = new int[] { 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, Double.MIN_VALUE };
 		setLayout( gridBagLayout );
 
 		final JLabel lblTitle = new JLabel( "Configure semi-automatic tracker." );
 		lblTitle.setFont( lblTitle.getFont().deriveFont( lblTitle.getFont().getSize() + 5f ) );
 		final GridBagConstraints gbc_lblTitle = new GridBagConstraints();
-		gbc_lblTitle.gridwidth = 3;
-		gbc_lblTitle.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblTitle.gridwidth = 2;
+		gbc_lblTitle.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblTitle.gridx = 0;
 		gbc_lblTitle.gridy = 0;
 		add( lblTitle, gbc_lblTitle );
@@ -38,8 +99,8 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		final JLabel lblDetection = new JLabel( "Detection." );
 		lblDetection.setFont( lblDetection.getFont().deriveFont( lblDetection.getFont().getStyle() | Font.BOLD ) );
 		final GridBagConstraints gbc_lblDetection = new GridBagConstraints();
-		gbc_lblDetection.gridwidth = 3;
-		gbc_lblDetection.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblDetection.gridwidth = 2;
+		gbc_lblDetection.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblDetection.gridx = 0;
 		gbc_lblDetection.gridy = 1;
 		add( lblDetection, gbc_lblDetection );
@@ -47,14 +108,13 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		final JLabel lblSetupId = new JLabel( "Setup ID:" );
 		final GridBagConstraints gbc_lblSetupId = new GridBagConstraints();
 		gbc_lblSetupId.anchor = GridBagConstraints.EAST;
-		gbc_lblSetupId.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblSetupId.insets = new Insets( 0, 5, 5, 5 );
 		gbc_lblSetupId.gridx = 0;
 		gbc_lblSetupId.gridy = 2;
 		add( lblSetupId, gbc_lblSetupId );
 
-		final JComboBox comboBox = new JComboBox();
+		final SetupIDComboBox comboBox = new SetupIDComboBox( spimData );
 		final GridBagConstraints gbc_comboBox = new GridBagConstraints();
-		gbc_comboBox.gridwidth = 2;
 		gbc_comboBox.insets = new Insets( 5, 5, 5, 5 );
 		gbc_comboBox.fill = GridBagConstraints.HORIZONTAL;
 		gbc_comboBox.gridx = 1;
@@ -62,6 +122,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		add( comboBox, gbc_comboBox );
 
 		final JLabel lblQualityFactor = new JLabel( "Quality factor:" );
+		lblQualityFactor.setToolTipText( QUALITY_FACTOR_TOOLTIP );
 		final GridBagConstraints gbc_lblQualityFactor = new GridBagConstraints();
 		gbc_lblQualityFactor.anchor = GridBagConstraints.EAST;
 		gbc_lblQualityFactor.insets = new Insets( 0, 0, 5, 5 );
@@ -69,15 +130,39 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblQualityFactor.gridy = 3;
 		add( lblQualityFactor, gbc_lblQualityFactor );
 
+		final BoundedValueDouble qualityFactor = new BoundedValueDouble( 0., 5., 1.2 );
+		final SliderPanelDouble qualityFactorSlider = new SliderPanelDouble( "", qualityFactor, 0.2 );
+		qualityFactorSlider.setToolTipText( QUALITY_FACTOR_TOOLTIP );
+		qualityFactorSlider.setNumColummns( 3 );
+		final GridBagConstraints gbc_lblQualityFactorSlider = new GridBagConstraints();
+		gbc_lblQualityFactorSlider.fill = GridBagConstraints.HORIZONTAL;
+		gbc_lblQualityFactorSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblQualityFactorSlider.gridx = 1;
+		gbc_lblQualityFactorSlider.gridy = 3;
+		add( qualityFactorSlider, gbc_lblQualityFactorSlider );
+
 		final JLabel lblDistanceFactor = new JLabel( "Distance factor:" );
+		lblDistanceFactor.setToolTipText( DISTANCE_FACTOR_TOOLTIP );
 		final GridBagConstraints gbc_lblDistanceFactor = new GridBagConstraints();
 		gbc_lblDistanceFactor.anchor = GridBagConstraints.EAST;
-		gbc_lblDistanceFactor.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblDistanceFactor.insets = new Insets( 0, 5, 5, 5 );
 		gbc_lblDistanceFactor.gridx = 0;
 		gbc_lblDistanceFactor.gridy = 4;
 		add( lblDistanceFactor, gbc_lblDistanceFactor );
 
+		final BoundedValueDouble distanceFactor = new BoundedValueDouble( 0., 5., 1.2 );
+		final SliderPanelDouble distanceFactorSlider = new SliderPanelDouble( "", distanceFactor, 0.2 );
+		distanceFactorSlider.setNumColummns( 3 );
+		distanceFactorSlider.setToolTipText( DISTANCE_FACTOR_TOOLTIP );
+		final GridBagConstraints gbc_lblDistanceFactorSlider = new GridBagConstraints();
+		gbc_lblDistanceFactorSlider.fill = GridBagConstraints.HORIZONTAL;
+		gbc_lblDistanceFactorSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblDistanceFactorSlider.gridx = 1;
+		gbc_lblDistanceFactorSlider.gridy = 4;
+		add( distanceFactorSlider, gbc_lblDistanceFactorSlider );
+
 		final JLabel lblNTimepoints = new JLabel( "N time-points:" );
+		lblNTimepoints.setToolTipText( N_TIMEPOINTS_TOOLTIP );
 		final GridBagConstraints gbc_lblNTimepoints = new GridBagConstraints();
 		gbc_lblNTimepoints.anchor = GridBagConstraints.EAST;
 		gbc_lblNTimepoints.insets = new Insets( 0, 0, 5, 5 );
@@ -85,19 +170,30 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblNTimepoints.gridy = 5;
 		add( lblNTimepoints, gbc_lblNTimepoints );
 
+		final BoundedValue nTimepoints = new BoundedValue( 1, nTimePoints, 20 );
+		final SliderPanel nTimepointsSlider = new SliderPanel( "", nTimepoints, 1 );
+		nTimepointsSlider.setNumColummns( 3 );
+		nTimepointsSlider.setToolTipText( N_TIMEPOINTS_TOOLTIP );
+		final GridBagConstraints gbc_lblNTimepointsSlider = new GridBagConstraints();
+		gbc_lblNTimepointsSlider.fill = GridBagConstraints.HORIZONTAL;
+		gbc_lblNTimepointsSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblNTimepointsSlider.gridx = 1;
+		gbc_lblNTimepointsSlider.gridy = 5;
+		add( nTimepointsSlider, gbc_lblNTimepointsSlider );
+
 		final JLabel lblTrackingDirection = new JLabel( "Tracking direction." );
 		lblTrackingDirection.setFont( lblTrackingDirection.getFont().deriveFont( lblTrackingDirection.getFont().getStyle() | Font.BOLD ) );
 		final GridBagConstraints gbc_lblTrackingDirection = new GridBagConstraints();
-		gbc_lblTrackingDirection.gridwidth = 3;
-		gbc_lblTrackingDirection.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblTrackingDirection.gridwidth = 2;
+		gbc_lblTrackingDirection.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblTrackingDirection.gridx = 0;
 		gbc_lblTrackingDirection.gridy = 6;
 		add( lblTrackingDirection, gbc_lblTrackingDirection );
 
 		final JPanel panelTrackingDirection = new JPanel();
 		final GridBagConstraints gbc_panelTrackingDirection = new GridBagConstraints();
-		gbc_panelTrackingDirection.insets = new Insets( 5, 5, 5, 5 );
-		gbc_panelTrackingDirection.gridwidth = 3;
+		gbc_panelTrackingDirection.insets = new Insets( 5, 5, 5, 0 );
+		gbc_panelTrackingDirection.gridwidth = 2;
 		gbc_panelTrackingDirection.fill = GridBagConstraints.VERTICAL;
 		gbc_panelTrackingDirection.gridx = 0;
 		gbc_panelTrackingDirection.gridy = 7;
@@ -109,69 +205,71 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		final JRadioButton rdbtnBackward = new JRadioButton( "Backward in time." );
 		panelTrackingDirection.add( rdbtnBackward );
 
-		final JLabel lblDealWithExisting = new JLabel( "Existing links." );
+		final JLabel lblDealWithExisting = new JLabel( "Existing spots." );
 		lblDealWithExisting.setFont( lblDealWithExisting.getFont().deriveFont( lblDealWithExisting.getFont().getStyle() | Font.BOLD ) );
 		final GridBagConstraints gbc_lblDealWithExisting = new GridBagConstraints();
-		gbc_lblDealWithExisting.gridwidth = 3;
-		gbc_lblDealWithExisting.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblDealWithExisting.gridwidth = 2;
+		gbc_lblDealWithExisting.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblDealWithExisting.gridx = 0;
 		gbc_lblDealWithExisting.gridy = 8;
 		add( lblDealWithExisting, gbc_lblDealWithExisting );
 
-		final JLabel lblAllowLinkingIf = new JLabel( "Allow linking if target spot has links?" );
+		final JCheckBox chckbxAllowLinkingIf = new JCheckBox( "Allow linking to an existing spot?" );
+		chckbxAllowLinkingIf.setToolTipText( ALLOW_LINKING_TO_EXISTING_TOOLTIP );
 		final GridBagConstraints gbc_lblAllowLinkingIf = new GridBagConstraints();
-		gbc_lblAllowLinkingIf.gridwidth = 3;
+		gbc_lblAllowLinkingIf.gridwidth = 2;
 		gbc_lblAllowLinkingIf.anchor = GridBagConstraints.WEST;
 		gbc_lblAllowLinkingIf.fill = GridBagConstraints.VERTICAL;
-		gbc_lblAllowLinkingIf.insets = new Insets( 5, 5, 5, 5 );
+		gbc_lblAllowLinkingIf.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblAllowLinkingIf.gridx = 0;
 		gbc_lblAllowLinkingIf.gridy = 9;
-		add( lblAllowLinkingIf, gbc_lblAllowLinkingIf );
+		add( chckbxAllowLinkingIf, gbc_lblAllowLinkingIf );
 
 		final JCheckBox chckbxLinkIncoming = new JCheckBox( "Link even if target has incoming links." );
+		chckbxLinkIncoming.setToolTipText( ALLOW_LINKING_IF_INCOMING_TOOLTIP );
 		final GridBagConstraints gbc_chckbxLinkIncoming = new GridBagConstraints();
-		gbc_chckbxLinkIncoming.insets = new Insets( 5, 5, 5, 5 );
+		gbc_chckbxLinkIncoming.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxLinkIncoming.anchor = GridBagConstraints.WEST;
-		gbc_chckbxLinkIncoming.gridwidth = 2;
 		gbc_chckbxLinkIncoming.gridx = 1;
 		gbc_chckbxLinkIncoming.gridy = 10;
 		add( chckbxLinkIncoming, gbc_chckbxLinkIncoming );
 
 		final JCheckBox chckbxLinkOutgoing = new JCheckBox( "Link even if target has outgoing links." );
+		chckbxLinkOutgoing.setToolTipText( ALLOW_LINKING_IF_OUTGOING_TOOLTIP );
 		final GridBagConstraints gbc_chckbxLinkOutgoing = new GridBagConstraints();
-		gbc_chckbxLinkOutgoing.insets = new Insets( 5, 5, 5, 5 );
+		gbc_chckbxLinkOutgoing.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxLinkOutgoing.anchor = GridBagConstraints.WEST;
-		gbc_chckbxLinkOutgoing.gridwidth = 2;
 		gbc_chckbxLinkOutgoing.gridx = 1;
 		gbc_chckbxLinkOutgoing.gridy = 11;
 		add( chckbxLinkOutgoing, gbc_chckbxLinkOutgoing );
 
-		final JLabel lblContinueTrackingIf = new JLabel( "Continue tracking if source and target spots are already linked?" );
-		final GridBagConstraints gbc_lblContinueTrackingIf = new GridBagConstraints();
-		gbc_lblContinueTrackingIf.insets = new Insets( 5, 5, 5, 5 );
-		gbc_lblContinueTrackingIf.anchor = GridBagConstraints.WEST;
-		gbc_lblContinueTrackingIf.gridwidth = 3;
-		gbc_lblContinueTrackingIf.gridx = 0;
-		gbc_lblContinueTrackingIf.gridy = 12;
-		add( lblContinueTrackingIf, gbc_lblContinueTrackingIf );
-
-		final JCheckBox chckbxContinueTracking = new JCheckBox( "Continue tracking." );
+		final JCheckBox chckbxContinueTracking = new JCheckBox( "<html>"
+				+ "Continue tracking if source and target spots are already linked.</html>" );
+		chckbxContinueTracking.setVerticalTextPosition( SwingConstants.TOP );
+		chckbxContinueTracking.setVerticalAlignment( SwingConstants.TOP );
+		chckbxContinueTracking.setToolTipText( CONTINUE_LINKING_TOOLTIP );
 		final GridBagConstraints gbc_chckbxContinueTracking = new GridBagConstraints();
-		gbc_chckbxContinueTracking.insets = new Insets( 5, 5, 5, 5 );
-		gbc_chckbxContinueTracking.anchor = GridBagConstraints.WEST;
-		gbc_chckbxContinueTracking.gridwidth = 2;
+		gbc_chckbxContinueTracking.anchor = GridBagConstraints.NORTHWEST;
+		gbc_chckbxContinueTracking.fill = GridBagConstraints.BOTH;
+		gbc_chckbxContinueTracking.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxContinueTracking.gridx = 1;
-		gbc_chckbxContinueTracking.gridy = 13;
+		gbc_chckbxContinueTracking.gridy = 12;
 		add( chckbxContinueTracking, gbc_chckbxContinueTracking );
+
+		chckbxAllowLinkingIf.addItemListener( ( e ) -> {
+			chckbxLinkIncoming.setEnabled( chckbxAllowLinkingIf.isSelected() );
+			chckbxLinkOutgoing.setEnabled( chckbxAllowLinkingIf.isSelected() );
+			chckbxContinueTracking.setEnabled( chckbxAllowLinkingIf.isSelected() );
+		} );
 
 		final JPanel panelButtons = new JPanel();
 		final GridBagConstraints gbc_panelButtons = new GridBagConstraints();
 		gbc_panelButtons.anchor = GridBagConstraints.SOUTH;
-		gbc_panelButtons.gridwidth = 3;
-		gbc_panelButtons.insets = new Insets( 5, 5, 5, 5 );
+		gbc_panelButtons.gridwidth = 2;
+		gbc_panelButtons.insets = new Insets( 5, 5, 0, 0 );
 		gbc_panelButtons.fill = GridBagConstraints.HORIZONTAL;
 		gbc_panelButtons.gridx = 0;
-		gbc_panelButtons.gridy = 14;
+		gbc_panelButtons.gridy = 13;
 		add( panelButtons, gbc_panelButtons );
 		panelButtons.setLayout( new BoxLayout( panelButtons, BoxLayout.X_AXIS ) );
 
@@ -181,11 +279,8 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		final Component horizontalGlue = Box.createHorizontalGlue();
 		panelButtons.add( horizontalGlue );
 
-		final JButton btnCancel = new JButton( "Cancel" );
-		panelButtons.add( btnCancel );
-
-		final JButton btnApply = new JButton( "Apply" );
-		panelButtons.add( btnApply );
+		final JButton btnTrack = new JButton( "Track" );
+		panelButtons.add( btnTrack );
 	}
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -16,6 +16,7 @@ import javax.swing.WindowConstants;
 
 import org.mastodon.app.ui.ViewMenuBuilder.MenuItem;
 import org.mastodon.app.ui.settings.SettingsPanel;
+import org.mastodon.collection.RefCollections;
 import org.mastodon.grouping.GroupHandle;
 import org.mastodon.model.NavigationHandler;
 import org.mastodon.model.SelectionModel;
@@ -79,7 +80,11 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 				return;
 
 			final SelectionModel< Spot, Link > selectionModel = appModel.getAppModel().getSelectionModel();
-			final Collection< Spot > spots = selectionModel.getSelectedVertices();
+			final Collection< Spot > selectedSpots = selectionModel.getSelectedVertices();
+			final Collection< Spot > spots = RefCollections.createRefList(
+					appModel.getAppModel().getModel().getGraph().vertices(), selectedSpots.size() );
+			spots.addAll( selectedSpots );
+
 			final Map< String, Object > settings = ( currentSettings == null )
 					? SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap()
 							: currentSettings;
@@ -89,7 +94,8 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 			final SemiAutomaticTracker tracker = ( SemiAutomaticTracker ) Computers.binary(
 					ops, SemiAutomaticTracker.class, model, spots, settings,
 					spimData,
-					navigationHandler );
+					navigationHandler,
+					selectionModel );
 			tracker.compute( spots, settings, model );
 		}
 	};

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -130,7 +130,7 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 
 		final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
 		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
-		final SemiAutomaticTrackerConfigPage page = new SemiAutomaticTrackerConfigPage( "Settings", styleManager, spimData, groupHandle )
+		final SemiAutomaticTrackerConfigPage page = new SemiAutomaticTrackerConfigPage( "Settings", styleManager, spimData, groupHandle, performSemiAutoTrackAction )
 		{
 			@Override
 			public void apply()

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -78,9 +78,6 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 
 			final SelectionModel< Spot, Link > selectionModel = appModel.getAppModel().getSelectionModel();
 			final Collection< Spot > spots = selectionModel.getSelectedVertices();
-			if ( spots == null || spots.isEmpty() )
-				return;
-
 			final Map< String, Object > settings = ( currentSettings == null )
 					? SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap()
 							: currentSettings;

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -166,6 +166,7 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 				currentSettings.putAll( forwardDefaultStyle.getAsSettingsMap() );
 			}
 		};
+		page.apply();
 		final SettingsPanel settings = new SettingsPanel();
 		settings.addPage( page );
 

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -16,6 +16,8 @@ import javax.swing.WindowConstants;
 
 import org.mastodon.app.ui.ViewMenuBuilder.MenuItem;
 import org.mastodon.app.ui.settings.SettingsPanel;
+import org.mastodon.grouping.GroupHandle;
+import org.mastodon.model.NavigationHandler;
 import org.mastodon.model.SelectionModel;
 import org.mastodon.plugin.MastodonPlugin;
 import org.mastodon.plugin.MastodonPluginAppModel;
@@ -86,7 +88,8 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 			final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
 			final SemiAutomaticTracker tracker = ( SemiAutomaticTracker ) Computers.binary(
 					ops, SemiAutomaticTracker.class, model, spots, settings,
-					spimData );
+					spimData,
+					navigationHandler );
 			tracker.compute( spots, settings, model );
 		}
 	};
@@ -106,6 +109,8 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 	};
 
 	private JDialog dialog;
+
+	private NavigationHandler< Spot, Link > navigationHandler;
 
 	@Override
 	public Map< String, String > getMenuTexts()
@@ -137,9 +142,12 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 	{
 		this.appModel = appModel;
 
+		final GroupHandle groupHandle = appModel.getAppModel().getGroupManager().createGroupHandle();
+		this.navigationHandler = groupHandle.getModel( appModel.getAppModel().NAVIGATION );
+
 		final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
 		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
-		final SemiAutomaticTrackerConfigPage page = new SemiAutomaticTrackerConfigPage( "Settings", styleManager, spimData )
+		final SemiAutomaticTrackerConfigPage page = new SemiAutomaticTrackerConfigPage( "Settings", styleManager, spimData, groupHandle )
 		{
 			@Override
 			public void apply()

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -1,13 +1,21 @@
 package org.mastodon.trackmate.semiauto;
 
+import java.awt.BorderLayout;
+import java.awt.Frame;
 import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.swing.JDialog;
+import javax.swing.WindowConstants;
+
 import org.mastodon.app.ui.ViewMenuBuilder.MenuItem;
+import org.mastodon.app.ui.settings.SettingsPanel;
 import org.mastodon.model.SelectionModel;
 import org.mastodon.plugin.MastodonPlugin;
 import org.mastodon.plugin.MastodonPluginAppModel;
@@ -15,6 +23,9 @@ import org.mastodon.revised.mamut.MamutMenuBuilder;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.trackmate.semiauto.ui.SemiAutomaticTrackerConfigPage;
+import org.mastodon.trackmate.semiauto.ui.SemiAutomaticTrackerSettings;
+import org.mastodon.trackmate.semiauto.ui.SemiAutomaticTrackerSettingsManager;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.behaviour.util.AbstractNamedAction;
@@ -29,8 +40,10 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 {
 
 	private static final String ACTION_1 = "[semiautotrack] track";
+	private static final String ACTION_2 = "[semiautotrack] show config";
 
 	private static final String[] ACTION_1_KEYS = new String[] { "ctrl T" };
+	private static final String[] ACTION_2_KEYS = new String[] { "not mapped" };
 
 	@Parameter
 	private OpService ops;
@@ -39,12 +52,21 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 
 	private static Map< String, String > menuTexts = new HashMap<>();
 
+	private final Map< String, Object > currentSettings;
+
+	public SemiAutomaticTrackerPlugin()
+	{
+		this.currentSettings = new HashMap<>();
+		currentSettings.putAll( SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap() );
+	}
+
 	static
 	{
 		menuTexts.put( ACTION_1, "Semi-automatic tracking" );
+		menuTexts.put( ACTION_2, "Configure semi-automatic tracker" );
 	}
 
-	private final AbstractNamedAction action1 = new AbstractNamedAction( ACTION_1 )
+	private final AbstractNamedAction performSemiAutoTrackAction = new AbstractNamedAction( ACTION_1 )
 	{
 		private static final long serialVersionUID = 1L;
 
@@ -59,9 +81,11 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 			if ( spots == null || spots.isEmpty() )
 				return;
 
-			final Map< String, Object > settings = SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap();
+			final Map< String, Object > settings = ( currentSettings == null )
+					? SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap()
+							: currentSettings;
 			final Model model = appModel.getAppModel().getModel();
-			
+
 			final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
 			final SemiAutomaticTracker tracker = ( SemiAutomaticTracker ) Computers.binary(
 					ops, SemiAutomaticTracker.class, model, spots, settings,
@@ -69,6 +93,22 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 			tracker.compute( spots, settings, model );
 		}
 	};
+
+	private final AbstractNamedAction toggleConfigDialogVisibility = new AbstractNamedAction( ACTION_2)
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void actionPerformed( final ActionEvent e )
+		{
+			if (null == dialog)
+				return;
+			dialog.setVisible( !dialog.isVisible() );
+		}
+	};
+
+	private JDialog dialog;
 
 	@Override
 	public Map< String, String > getMenuTexts()
@@ -82,19 +122,54 @@ public class SemiAutomaticTrackerPlugin implements MastodonPlugin
 		return Arrays.asList(
 				MamutMenuBuilder.menu( "Plugins",
 						MamutMenuBuilder.menu( "TrackMate",
-								MamutMenuBuilder.item( ACTION_1 ) ) ) );
+								MamutMenuBuilder.item( ACTION_1 ) ) ),
+				MamutMenuBuilder.menu( "Plugins",
+						MamutMenuBuilder.menu( "TrackMate",
+								MamutMenuBuilder.item( ACTION_2 ) ) ));
 	}
 
 	@Override
 	public void installGlobalActions( final Actions actions )
 	{
-		actions.namedAction( action1, ACTION_1_KEYS );
+		actions.namedAction( performSemiAutoTrackAction, ACTION_1_KEYS );
+		actions.namedAction( toggleConfigDialogVisibility, ACTION_2_KEYS );
 	}
 
 	@Override
 	public void setAppModel( final MastodonPluginAppModel appModel )
 	{
 		this.appModel = appModel;
-	}
 
+		final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
+		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
+		final SemiAutomaticTrackerConfigPage page = new SemiAutomaticTrackerConfigPage( "Settings", styleManager, spimData )
+		{
+			@Override
+			public void apply()
+			{
+				super.apply();
+				final SemiAutomaticTrackerSettings forwardDefaultStyle = styleManager.getForwardDefaultStyle();
+				currentSettings.clear();
+				currentSettings.putAll( forwardDefaultStyle.getAsSettingsMap() );
+			}
+		};
+		final SettingsPanel settings = new SettingsPanel();
+		settings.addPage( page );
+
+		dialog = new JDialog( ( Frame ) null, "Semi-automatic tracker settings" );
+		dialog.getContentPane().add( settings, BorderLayout.CENTER );
+		settings.onOk( () -> dialog.setVisible( false )  );
+		settings.onCancel( () -> dialog.setVisible( false ) );
+
+		dialog.setDefaultCloseOperation( WindowConstants.DO_NOTHING_ON_CLOSE );
+		dialog.addWindowListener( new WindowAdapter()
+		{
+			@Override
+			public void windowClosing( final WindowEvent e )
+			{
+				settings.cancel();
+			}
+		} );
+		dialog.pack();
+	}
 }

--- a/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/SemiAutomaticTrackerPlugin.java
@@ -1,0 +1,100 @@
+package org.mastodon.trackmate.semiauto;
+
+import java.awt.event.ActionEvent;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mastodon.app.ui.ViewMenuBuilder.MenuItem;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.plugin.MastodonPlugin;
+import org.mastodon.plugin.MastodonPluginAppModel;
+import org.mastodon.revised.mamut.MamutMenuBuilder;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.Spot;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+import org.scijava.ui.behaviour.util.Actions;
+
+import bdv.spimdata.SpimDataMinimal;
+import net.imagej.ops.OpService;
+import net.imagej.ops.special.computer.Computers;
+
+@Plugin( type = SemiAutomaticTrackerPlugin.class )
+public class SemiAutomaticTrackerPlugin implements MastodonPlugin
+{
+
+	private static final String ACTION_1 = "[semiautotrack] track";
+
+	private static final String[] ACTION_1_KEYS = new String[] { "ctrl T" };
+
+	@Parameter
+	private OpService ops;
+
+	private MastodonPluginAppModel appModel;
+
+	private static Map< String, String > menuTexts = new HashMap<>();
+
+	static
+	{
+		menuTexts.put( ACTION_1, "Semi-automatic tracking" );
+	}
+
+	private final AbstractNamedAction action1 = new AbstractNamedAction( ACTION_1 )
+	{
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void actionPerformed( final ActionEvent e )
+		{
+			if ( null == appModel )
+				return;
+
+			final SelectionModel< Spot, Link > selectionModel = appModel.getAppModel().getSelectionModel();
+			final Collection< Spot > spots = selectionModel.getSelectedVertices();
+			if ( spots == null || spots.isEmpty() )
+				return;
+
+			final Map< String, Object > settings = SemiAutomaticTrackerKeys.getDefaultDetectorSettingsMap();
+			final Model model = appModel.getAppModel().getModel();
+			
+			final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getAppModel().getSharedBdvData().getSpimData();
+			final SemiAutomaticTracker tracker = ( SemiAutomaticTracker ) Computers.binary(
+					ops, SemiAutomaticTracker.class, model, spots, settings,
+					spimData );
+			tracker.compute( spots, settings, model );
+		}
+	};
+
+	@Override
+	public Map< String, String > getMenuTexts()
+	{
+		return menuTexts;
+	}
+
+	@Override
+	public List< MenuItem > getMenuItems()
+	{
+		return Arrays.asList(
+				MamutMenuBuilder.menu( "Plugins",
+						MamutMenuBuilder.menu( "TrackMate",
+								MamutMenuBuilder.item( ACTION_1 ) ) ) );
+	}
+
+	@Override
+	public void installGlobalActions( final Actions actions )
+	{
+		actions.namedAction( action1, ACTION_1_KEYS );
+	}
+
+	@Override
+	public void setAppModel( final MastodonPluginAppModel appModel )
+	{
+		this.appModel = appModel;
+	}
+
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
 
+import javax.swing.Action;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
@@ -32,11 +33,11 @@ import mpicbg.spim.data.SpimDataException;
 public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettingsPage< StyleProfile< SemiAutomaticTrackerSettings > >
 {
 
-	public SemiAutomaticTrackerConfigPage( final String treePath, final SemiAutomaticTrackerSettingsManager settingsManager, final SpimDataMinimal spimData, final GroupHandle groupHandle )
+	public SemiAutomaticTrackerConfigPage( final String treePath, final SemiAutomaticTrackerSettingsManager settingsManager, final SpimDataMinimal spimData, final GroupHandle groupHandle, final Action trackAction )
 	{
 		super( treePath,
 				new StyleProfileManager<>( settingsManager, new SemiAutomaticTrackerSettingsManager( false ) ),
-				new SemiAutomaticTrackerSettingsEditPanel( settingsManager.getDefaultStyle(), spimData, groupHandle ) );
+				new SemiAutomaticTrackerSettingsEditPanel( settingsManager.getDefaultStyle(), spimData, groupHandle, trackAction ) );
 	}
 
 	static class SemiAutomaticTrackerSettingsEditPanel implements SemiAutomaticTrackerSettings.UpdateListener, SelectAndEditProfileSettingsPage.ProfileEditPanel< StyleProfile< SemiAutomaticTrackerSettings > >
@@ -50,10 +51,10 @@ public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettings
 
 		private final SynchronizedList< ModificationListener > modificationListeners;
 
-		public SemiAutomaticTrackerSettingsEditPanel( final SemiAutomaticTrackerSettings initialSettings, final SpimDataMinimal spimData, final GroupHandle groupHandle )
+		public SemiAutomaticTrackerSettingsEditPanel( final SemiAutomaticTrackerSettings initialSettings, final SpimDataMinimal spimData, final GroupHandle groupHandle, final Action trackAction )
 		{
 			editedSettings = initialSettings.copy( "Edited" );
-			settingsPanel = new SemiAutomaticTrackerConfigPanel( spimData, editedSettings, groupHandle );
+			settingsPanel = new SemiAutomaticTrackerConfigPanel( spimData, editedSettings, groupHandle, trackAction );
 			modificationListeners = new Listeners.SynchronizedList<>();
 			editedSettings.updateListeners().add( this );
 		}
@@ -115,7 +116,7 @@ public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettings
 		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
 
 		final SettingsPanel settings = new SettingsPanel();
-		settings.addPage( new SemiAutomaticTrackerConfigPage( "Semi-automatic tracker settings", styleManager, spimData, groupHandle ) );
+		settings.addPage( new SemiAutomaticTrackerConfigPage( "Semi-automatic tracker settings", styleManager, spimData, groupHandle, null ) );
 
 		final JDialog dialog = new JDialog( ( Frame ) null, "Settings" );
 		dialog.getContentPane().add( settings, BorderLayout.CENTER );

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
@@ -1,0 +1,136 @@
+package org.mastodon.trackmate.semiauto.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.WindowConstants;
+
+import org.mastodon.app.ui.settings.ModificationListener;
+import org.mastodon.app.ui.settings.SelectAndEditProfileSettingsPage;
+import org.mastodon.app.ui.settings.SettingsPanel;
+import org.mastodon.app.ui.settings.style.StyleProfile;
+import org.mastodon.app.ui.settings.style.StyleProfileManager;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.util.Listeners;
+import org.mastodon.util.Listeners.SynchronizedList;
+import org.scijava.Context;
+
+import bdv.spimdata.SpimDataMinimal;
+import mpicbg.spim.data.SpimDataException;
+
+public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettingsPage< StyleProfile< SemiAutomaticTrackerSettings > >
+{
+
+	public SemiAutomaticTrackerConfigPage( final String treePath, final SemiAutomaticTrackerSettingsManager settingsManager, final SpimDataMinimal spimData )
+	{
+		super( treePath,
+				new StyleProfileManager<>( settingsManager, new SemiAutomaticTrackerSettingsManager( false ) ),
+				new SemiAutomaticTrackerSettingsEditPanel( settingsManager.getDefaultStyle(), spimData ) );
+	}
+
+	static class SemiAutomaticTrackerSettingsEditPanel implements SemiAutomaticTrackerSettings.UpdateListener, SelectAndEditProfileSettingsPage.ProfileEditPanel< StyleProfile< SemiAutomaticTrackerSettings > >
+	{
+
+		private final SemiAutomaticTrackerSettings editedSettings;
+
+		private final SemiAutomaticTrackerConfigPanel settingsPanel;
+
+		private boolean trackModifications = true;
+
+		private final SynchronizedList< ModificationListener > modificationListeners;
+
+		public SemiAutomaticTrackerSettingsEditPanel( final SemiAutomaticTrackerSettings initialSettings, final SpimDataMinimal spimData )
+		{
+			editedSettings = initialSettings.copy( "Edited" );
+			settingsPanel = new SemiAutomaticTrackerConfigPanel( spimData, editedSettings );
+			modificationListeners = new Listeners.SynchronizedList<>();
+			editedSettings.updateListeners().add( this );
+		}
+
+		@Override
+		public Listeners< ModificationListener > modificationListeners()
+		{
+			return modificationListeners;
+		}
+
+		@Override
+		public void loadProfile( final StyleProfile< SemiAutomaticTrackerSettings > profile )
+		{
+			trackModifications = false;
+			editedSettings.set( profile.getStyle() );
+			trackModifications = true;
+		}
+
+		@Override
+		public void storeProfile( final StyleProfile< SemiAutomaticTrackerSettings > profile )
+		{
+			trackModifications = false;
+			editedSettings.setName( profile.getStyle().getName() );
+			trackModifications = true;
+			profile.getStyle().set( editedSettings );
+		}
+
+		@Override
+		public JPanel getJPanel()
+		{
+			return settingsPanel;
+		}
+
+		@Override
+		public void settingsChanged()
+		{
+			if ( trackModifications )
+				modificationListeners.list.forEach( ModificationListener::modified );
+		}
+	}
+
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+//		final MamutProject project = new MamutProjectIO().load( projectFile );
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+
+		final Context context = new Context();
+		final WindowManager windowManager = new WindowManager( context );
+		windowManager.getProjectManager().open( project );
+		final SpimDataMinimal spimData = ( SpimDataMinimal ) windowManager.getAppModel().getSharedBdvData().getSpimData();
+
+		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
+
+		final SettingsPanel settings = new SettingsPanel();
+		settings.addPage( new SemiAutomaticTrackerConfigPage( "Semi-automatic tracker settings", styleManager, spimData ) );
+
+		final JDialog dialog = new JDialog( ( Frame ) null, "Settings" );
+		dialog.getContentPane().add( settings, BorderLayout.CENTER );
+
+		settings.onOk( () -> dialog.setVisible( false ) );
+		settings.onCancel( () -> dialog.setVisible( false ) );
+
+		dialog.setDefaultCloseOperation( WindowConstants.DO_NOTHING_ON_CLOSE );
+		dialog.addWindowListener( new WindowAdapter()
+		{
+			@Override
+			public void windowClosing( final WindowEvent e )
+			{
+				settings.cancel();
+			}
+		} );
+
+		dialog.pack();
+		dialog.setVisible( true );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPage.java
@@ -19,6 +19,7 @@ import org.mastodon.app.ui.settings.SelectAndEditProfileSettingsPage;
 import org.mastodon.app.ui.settings.SettingsPanel;
 import org.mastodon.app.ui.settings.style.StyleProfile;
 import org.mastodon.app.ui.settings.style.StyleProfileManager;
+import org.mastodon.grouping.GroupHandle;
 import org.mastodon.revised.mamut.MamutProject;
 import org.mastodon.revised.mamut.WindowManager;
 import org.mastodon.util.Listeners;
@@ -31,11 +32,11 @@ import mpicbg.spim.data.SpimDataException;
 public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettingsPage< StyleProfile< SemiAutomaticTrackerSettings > >
 {
 
-	public SemiAutomaticTrackerConfigPage( final String treePath, final SemiAutomaticTrackerSettingsManager settingsManager, final SpimDataMinimal spimData )
+	public SemiAutomaticTrackerConfigPage( final String treePath, final SemiAutomaticTrackerSettingsManager settingsManager, final SpimDataMinimal spimData, final GroupHandle groupHandle )
 	{
 		super( treePath,
 				new StyleProfileManager<>( settingsManager, new SemiAutomaticTrackerSettingsManager( false ) ),
-				new SemiAutomaticTrackerSettingsEditPanel( settingsManager.getDefaultStyle(), spimData ) );
+				new SemiAutomaticTrackerSettingsEditPanel( settingsManager.getDefaultStyle(), spimData, groupHandle ) );
 	}
 
 	static class SemiAutomaticTrackerSettingsEditPanel implements SemiAutomaticTrackerSettings.UpdateListener, SelectAndEditProfileSettingsPage.ProfileEditPanel< StyleProfile< SemiAutomaticTrackerSettings > >
@@ -49,10 +50,10 @@ public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettings
 
 		private final SynchronizedList< ModificationListener > modificationListeners;
 
-		public SemiAutomaticTrackerSettingsEditPanel( final SemiAutomaticTrackerSettings initialSettings, final SpimDataMinimal spimData )
+		public SemiAutomaticTrackerSettingsEditPanel( final SemiAutomaticTrackerSettings initialSettings, final SpimDataMinimal spimData, final GroupHandle groupHandle )
 		{
 			editedSettings = initialSettings.copy( "Edited" );
-			settingsPanel = new SemiAutomaticTrackerConfigPanel( spimData, editedSettings );
+			settingsPanel = new SemiAutomaticTrackerConfigPanel( spimData, editedSettings, groupHandle );
 			modificationListeners = new Listeners.SynchronizedList<>();
 			editedSettings.updateListeners().add( this );
 		}
@@ -109,10 +110,12 @@ public class SemiAutomaticTrackerConfigPage extends SelectAndEditProfileSettings
 		windowManager.getProjectManager().open( project );
 		final SpimDataMinimal spimData = ( SpimDataMinimal ) windowManager.getAppModel().getSharedBdvData().getSpimData();
 
+		final GroupHandle groupHandle = windowManager.getAppModel().getGroupManager().createGroupHandle();
+
 		final SemiAutomaticTrackerSettingsManager styleManager = new SemiAutomaticTrackerSettingsManager();
 
 		final SettingsPanel settings = new SettingsPanel();
-		settings.addPage( new SemiAutomaticTrackerConfigPage( "Semi-automatic tracker settings", styleManager, spimData ) );
+		settings.addPage( new SemiAutomaticTrackerConfigPage( "Semi-automatic tracker settings", styleManager, spimData, groupHandle ) );
 
 		final JDialog dialog = new JDialog( ( Frame ) null, "Settings" );
 		dialog.getContentPane().add( settings, BorderLayout.CENTER );

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
@@ -1,4 +1,4 @@
-package org.mastodon.trackmate.semiauto;
+package org.mastodon.trackmate.semiauto.ui;
 
 import java.awt.Component;
 import java.awt.Font;

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
@@ -10,6 +10,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ItemListener;
 
+import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -82,7 +83,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 			+ "target spots. "
 			+ "</p></html>";
 
-	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData, final SemiAutomaticTrackerSettings editedSettings, final GroupHandle groupHandle )
+	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData, final SemiAutomaticTrackerSettings editedSettings, final GroupHandle groupHandle, final Action trackAction )
 	{
 		final int nTimePoints = ( null == spimData )
 				? 100
@@ -304,8 +305,11 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		final Component horizontalGlue = Box.createHorizontalGlue();
 		panelButtons.add( horizontalGlue );
 
-		final JButton btnTrack = new JButton( "Track" );
-		panelButtons.add( btnTrack );
+		if (null != trackAction)
+		{
+			final JButton btnTrack = new JButton( trackAction );
+			panelButtons.add( btnTrack );
+		}
 
 		final UpdateListener refresher = () -> {
 			comboBox.setSelectedSetupID( editedSettings.getSetupID() );

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
@@ -20,6 +20,8 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.SwingConstants;
 
+import org.mastodon.app.ui.GroupLocksPanel;
+import org.mastodon.grouping.GroupHandle;
 import org.mastodon.trackmate.semiauto.ui.SemiAutomaticTrackerSettings.UpdateListener;
 import org.mastodon.trackmate.ui.wizard.util.SetupIDComboBox;
 
@@ -80,7 +82,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 			+ "target spots. "
 			+ "</p></html>";
 
-	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData, final SemiAutomaticTrackerSettings editedSettings )
+	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData, final SemiAutomaticTrackerSettings editedSettings, final GroupHandle groupHandle )
 	{
 		final int nTimePoints = ( null == spimData )
 				? 100
@@ -88,9 +90,9 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 
 		final GridBagLayout gridBagLayout = new GridBagLayout();
 		gridBagLayout.columnWidths = new int[] { 0, 0, 0 };
-		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, Double.MIN_VALUE };
-		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, Double.MIN_VALUE };
 		setLayout( gridBagLayout );
 
 		final JLabel lblDetection = new JLabel( "Detection." );
@@ -267,6 +269,27 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_chckbxContinueTracking.gridy = 11;
 		add( chckbxContinueTracking, gbc_chckbxContinueTracking );
 
+		final JLabel lblNavigation = new JLabel( "Navigation." );
+		lblNavigation.setFont( lblNavigation.getFont().deriveFont( lblNavigation.getFont().getStyle() | Font.BOLD ) );
+		final GridBagConstraints gbc_lblNavigation = new GridBagConstraints();
+		gbc_lblNavigation.gridwidth = 2;
+		gbc_lblNavigation.insets = new Insets( 0, 0, 5, 0 );
+		gbc_lblNavigation.gridx = 0;
+		gbc_lblNavigation.gridy = 12;
+		add( lblNavigation, gbc_lblNavigation );
+
+		if ( null != groupHandle )
+		{
+			final GroupLocksPanel groupLocksPanel = new GroupLocksPanel( groupHandle );
+			final GridBagConstraints gbc_groupLocksPanel = new GridBagConstraints();
+			gbc_groupLocksPanel.gridwidth = 2;
+			gbc_groupLocksPanel.insets = new Insets( 0, 0, 5, 0 );
+			gbc_groupLocksPanel.fill = GridBagConstraints.BOTH;
+			gbc_groupLocksPanel.gridx = 0;
+			gbc_groupLocksPanel.gridy = 13;
+			add( groupLocksPanel, gbc_groupLocksPanel );
+		}
+
 		final JPanel panelButtons = new JPanel();
 		final GridBagConstraints gbc_panelButtons = new GridBagConstraints();
 		gbc_panelButtons.anchor = GridBagConstraints.SOUTH;
@@ -274,7 +297,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_panelButtons.insets = new Insets( 5, 5, 0, 0 );
 		gbc_panelButtons.fill = GridBagConstraints.HORIZONTAL;
 		gbc_panelButtons.gridx = 0;
-		gbc_panelButtons.gridy = 12;
+		gbc_panelButtons.gridy = 14;
 		add( panelButtons, gbc_panelButtons );
 		panelButtons.setLayout( new BoxLayout( panelButtons, BoxLayout.X_AXIS ) );
 

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerConfigPanel.java
@@ -1,13 +1,18 @@
 package org.mastodon.trackmate.semiauto.ui;
 
+import static org.mastodon.app.ui.settings.StyleElements.doubleElement;
+import static org.mastodon.app.ui.settings.StyleElements.intElement;
+
 import java.awt.Component;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ItemListener;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -15,6 +20,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.SwingConstants;
 
+import org.mastodon.trackmate.semiauto.ui.SemiAutomaticTrackerSettings.UpdateListener;
 import org.mastodon.trackmate.ui.wizard.util.SetupIDComboBox;
 
 import bdv.spimdata.SpimDataMinimal;
@@ -74,7 +80,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 			+ "target spots. "
 			+ "</p></html>";
 
-	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData )
+	public SemiAutomaticTrackerConfigPanel( final SpimDataMinimal spimData, final SemiAutomaticTrackerSettings editedSettings )
 	{
 		final int nTimePoints = ( null == spimData )
 				? 100
@@ -82,19 +88,10 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 
 		final GridBagLayout gridBagLayout = new GridBagLayout();
 		gridBagLayout.columnWidths = new int[] { 0, 0, 0 };
-		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, Double.MIN_VALUE };
-		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, Double.MIN_VALUE };
 		setLayout( gridBagLayout );
-
-		final JLabel lblTitle = new JLabel( "Configure semi-automatic tracker." );
-		lblTitle.setFont( lblTitle.getFont().deriveFont( lblTitle.getFont().getSize() + 5f ) );
-		final GridBagConstraints gbc_lblTitle = new GridBagConstraints();
-		gbc_lblTitle.gridwidth = 2;
-		gbc_lblTitle.insets = new Insets( 5, 5, 5, 0 );
-		gbc_lblTitle.gridx = 0;
-		gbc_lblTitle.gridy = 0;
-		add( lblTitle, gbc_lblTitle );
 
 		final JLabel lblDetection = new JLabel( "Detection." );
 		lblDetection.setFont( lblDetection.getFont().deriveFont( lblDetection.getFont().getStyle() | Font.BOLD ) );
@@ -102,7 +99,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblDetection.gridwidth = 2;
 		gbc_lblDetection.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblDetection.gridx = 0;
-		gbc_lblDetection.gridy = 1;
+		gbc_lblDetection.gridy = 0;
 		add( lblDetection, gbc_lblDetection );
 
 		final JLabel lblSetupId = new JLabel( "Setup ID:" );
@@ -110,15 +107,16 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblSetupId.anchor = GridBagConstraints.EAST;
 		gbc_lblSetupId.insets = new Insets( 0, 5, 5, 5 );
 		gbc_lblSetupId.gridx = 0;
-		gbc_lblSetupId.gridy = 2;
+		gbc_lblSetupId.gridy = 1;
 		add( lblSetupId, gbc_lblSetupId );
 
 		final SetupIDComboBox comboBox = new SetupIDComboBox( spimData );
+		comboBox.addItemListener( ( e ) -> editedSettings.setSetupID( comboBox.getSelectedSetupID() ) );
 		final GridBagConstraints gbc_comboBox = new GridBagConstraints();
-		gbc_comboBox.insets = new Insets( 5, 5, 5, 5 );
+		gbc_comboBox.insets = new Insets( 5, 5, 5, 0 );
 		gbc_comboBox.fill = GridBagConstraints.HORIZONTAL;
 		gbc_comboBox.gridx = 1;
-		gbc_comboBox.gridy = 2;
+		gbc_comboBox.gridy = 1;
 		add( comboBox, gbc_comboBox );
 
 		final JLabel lblQualityFactor = new JLabel( "Quality factor:" );
@@ -127,18 +125,19 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblQualityFactor.anchor = GridBagConstraints.EAST;
 		gbc_lblQualityFactor.insets = new Insets( 0, 0, 5, 5 );
 		gbc_lblQualityFactor.gridx = 0;
-		gbc_lblQualityFactor.gridy = 3;
+		gbc_lblQualityFactor.gridy = 2;
 		add( lblQualityFactor, gbc_lblQualityFactor );
 
-		final BoundedValueDouble qualityFactor = new BoundedValueDouble( 0., 5., 1.2 );
+		final BoundedValueDouble qualityFactor = doubleElement( "Quality factor", 0., 5., editedSettings::getQualityFactor, editedSettings::setQualityFactor )
+				.getValue();
 		final SliderPanelDouble qualityFactorSlider = new SliderPanelDouble( "", qualityFactor, 0.2 );
 		qualityFactorSlider.setToolTipText( QUALITY_FACTOR_TOOLTIP );
 		qualityFactorSlider.setNumColummns( 3 );
 		final GridBagConstraints gbc_lblQualityFactorSlider = new GridBagConstraints();
 		gbc_lblQualityFactorSlider.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblQualityFactorSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblQualityFactorSlider.insets = new Insets( 0, 0, 5, 0 );
 		gbc_lblQualityFactorSlider.gridx = 1;
-		gbc_lblQualityFactorSlider.gridy = 3;
+		gbc_lblQualityFactorSlider.gridy = 2;
 		add( qualityFactorSlider, gbc_lblQualityFactorSlider );
 
 		final JLabel lblDistanceFactor = new JLabel( "Distance factor:" );
@@ -147,18 +146,19 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblDistanceFactor.anchor = GridBagConstraints.EAST;
 		gbc_lblDistanceFactor.insets = new Insets( 0, 5, 5, 5 );
 		gbc_lblDistanceFactor.gridx = 0;
-		gbc_lblDistanceFactor.gridy = 4;
+		gbc_lblDistanceFactor.gridy = 3;
 		add( lblDistanceFactor, gbc_lblDistanceFactor );
 
-		final BoundedValueDouble distanceFactor = new BoundedValueDouble( 0., 5., 1.2 );
+		final BoundedValueDouble distanceFactor = doubleElement( "Distance factor", 0., 5., editedSettings::getDistanceFactor, editedSettings::setDistanceFactor )
+				.getValue();
 		final SliderPanelDouble distanceFactorSlider = new SliderPanelDouble( "", distanceFactor, 0.2 );
 		distanceFactorSlider.setNumColummns( 3 );
 		distanceFactorSlider.setToolTipText( DISTANCE_FACTOR_TOOLTIP );
 		final GridBagConstraints gbc_lblDistanceFactorSlider = new GridBagConstraints();
 		gbc_lblDistanceFactorSlider.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblDistanceFactorSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblDistanceFactorSlider.insets = new Insets( 0, 0, 5, 0 );
 		gbc_lblDistanceFactorSlider.gridx = 1;
-		gbc_lblDistanceFactorSlider.gridy = 4;
+		gbc_lblDistanceFactorSlider.gridy = 3;
 		add( distanceFactorSlider, gbc_lblDistanceFactorSlider );
 
 		final JLabel lblNTimepoints = new JLabel( "N time-points:" );
@@ -167,18 +167,19 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblNTimepoints.anchor = GridBagConstraints.EAST;
 		gbc_lblNTimepoints.insets = new Insets( 0, 0, 5, 5 );
 		gbc_lblNTimepoints.gridx = 0;
-		gbc_lblNTimepoints.gridy = 5;
+		gbc_lblNTimepoints.gridy = 4;
 		add( lblNTimepoints, gbc_lblNTimepoints );
 
-		final BoundedValue nTimepoints = new BoundedValue( 1, nTimePoints, 20 );
+		final BoundedValue nTimepoints = intElement( "N time-points", 1, nTimePoints, editedSettings::getnTimepoints, editedSettings::setNTimepoints )
+				.getValue();
 		final SliderPanel nTimepointsSlider = new SliderPanel( "", nTimepoints, 1 );
 		nTimepointsSlider.setNumColummns( 3 );
 		nTimepointsSlider.setToolTipText( N_TIMEPOINTS_TOOLTIP );
 		final GridBagConstraints gbc_lblNTimepointsSlider = new GridBagConstraints();
 		gbc_lblNTimepointsSlider.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblNTimepointsSlider.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblNTimepointsSlider.insets = new Insets( 0, 0, 5, 0 );
 		gbc_lblNTimepointsSlider.gridx = 1;
-		gbc_lblNTimepointsSlider.gridy = 5;
+		gbc_lblNTimepointsSlider.gridy = 4;
 		add( nTimepointsSlider, gbc_lblNTimepointsSlider );
 
 		final JLabel lblTrackingDirection = new JLabel( "Tracking direction." );
@@ -187,7 +188,7 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblTrackingDirection.gridwidth = 2;
 		gbc_lblTrackingDirection.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblTrackingDirection.gridx = 0;
-		gbc_lblTrackingDirection.gridy = 6;
+		gbc_lblTrackingDirection.gridy = 5;
 		add( lblTrackingDirection, gbc_lblTrackingDirection );
 
 		final JPanel panelTrackingDirection = new JPanel();
@@ -196,14 +197,20 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_panelTrackingDirection.gridwidth = 2;
 		gbc_panelTrackingDirection.fill = GridBagConstraints.VERTICAL;
 		gbc_panelTrackingDirection.gridx = 0;
-		gbc_panelTrackingDirection.gridy = 7;
+		gbc_panelTrackingDirection.gridy = 6;
 		add( panelTrackingDirection, gbc_panelTrackingDirection );
 
 		final JRadioButton rdbtnForward = new JRadioButton( "Forward in time." );
+		rdbtnForward.addItemListener( ( e ) -> editedSettings.setForwardInTime( rdbtnForward.isSelected() ) );
 		panelTrackingDirection.add( rdbtnForward );
 
 		final JRadioButton rdbtnBackward = new JRadioButton( "Backward in time." );
+		rdbtnBackward.addItemListener( ( e ) -> editedSettings.setForwardInTime( rdbtnForward.isSelected() ) );
 		panelTrackingDirection.add( rdbtnBackward );
+
+		final ButtonGroup buttonGroup = new ButtonGroup();
+		buttonGroup.add( rdbtnForward );
+		buttonGroup.add( rdbtnBackward );
 
 		final JLabel lblDealWithExisting = new JLabel( "Existing spots." );
 		lblDealWithExisting.setFont( lblDealWithExisting.getFont().deriveFont( lblDealWithExisting.getFont().getStyle() | Font.BOLD ) );
@@ -211,36 +218,39 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_lblDealWithExisting.gridwidth = 2;
 		gbc_lblDealWithExisting.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblDealWithExisting.gridx = 0;
-		gbc_lblDealWithExisting.gridy = 8;
+		gbc_lblDealWithExisting.gridy = 7;
 		add( lblDealWithExisting, gbc_lblDealWithExisting );
 
 		final JCheckBox chckbxAllowLinkingIf = new JCheckBox( "Allow linking to an existing spot?" );
 		chckbxAllowLinkingIf.setToolTipText( ALLOW_LINKING_TO_EXISTING_TOOLTIP );
+		chckbxAllowLinkingIf.addItemListener( ( e ) -> editedSettings.setAllowLinkingToExisting( chckbxAllowLinkingIf.isSelected() ) );
 		final GridBagConstraints gbc_lblAllowLinkingIf = new GridBagConstraints();
 		gbc_lblAllowLinkingIf.gridwidth = 2;
 		gbc_lblAllowLinkingIf.anchor = GridBagConstraints.WEST;
 		gbc_lblAllowLinkingIf.fill = GridBagConstraints.VERTICAL;
 		gbc_lblAllowLinkingIf.insets = new Insets( 5, 5, 5, 0 );
 		gbc_lblAllowLinkingIf.gridx = 0;
-		gbc_lblAllowLinkingIf.gridy = 9;
+		gbc_lblAllowLinkingIf.gridy = 8;
 		add( chckbxAllowLinkingIf, gbc_lblAllowLinkingIf );
 
 		final JCheckBox chckbxLinkIncoming = new JCheckBox( "Link even if target has incoming links." );
 		chckbxLinkIncoming.setToolTipText( ALLOW_LINKING_IF_INCOMING_TOOLTIP );
+		chckbxLinkIncoming.addItemListener( ( e ) -> editedSettings.setAllowIfIncomingLinks( chckbxLinkIncoming.isSelected() ) );
 		final GridBagConstraints gbc_chckbxLinkIncoming = new GridBagConstraints();
 		gbc_chckbxLinkIncoming.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxLinkIncoming.anchor = GridBagConstraints.WEST;
 		gbc_chckbxLinkIncoming.gridx = 1;
-		gbc_chckbxLinkIncoming.gridy = 10;
+		gbc_chckbxLinkIncoming.gridy = 9;
 		add( chckbxLinkIncoming, gbc_chckbxLinkIncoming );
 
 		final JCheckBox chckbxLinkOutgoing = new JCheckBox( "Link even if target has outgoing links." );
 		chckbxLinkOutgoing.setToolTipText( ALLOW_LINKING_IF_OUTGOING_TOOLTIP );
+		chckbxLinkOutgoing.addItemListener( ( e ) -> editedSettings.setAllowIfOutgoingLinks( chckbxLinkOutgoing.isSelected() ) );
 		final GridBagConstraints gbc_chckbxLinkOutgoing = new GridBagConstraints();
 		gbc_chckbxLinkOutgoing.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxLinkOutgoing.anchor = GridBagConstraints.WEST;
 		gbc_chckbxLinkOutgoing.gridx = 1;
-		gbc_chckbxLinkOutgoing.gridy = 11;
+		gbc_chckbxLinkOutgoing.gridy = 10;
 		add( chckbxLinkOutgoing, gbc_chckbxLinkOutgoing );
 
 		final JCheckBox chckbxContinueTracking = new JCheckBox( "<html>"
@@ -248,19 +258,14 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		chckbxContinueTracking.setVerticalTextPosition( SwingConstants.TOP );
 		chckbxContinueTracking.setVerticalAlignment( SwingConstants.TOP );
 		chckbxContinueTracking.setToolTipText( CONTINUE_LINKING_TOOLTIP );
+		chckbxContinueTracking.addItemListener( ( e ) -> editedSettings.setContinueIfLinked( chckbxContinueTracking.isSelected() ) );
 		final GridBagConstraints gbc_chckbxContinueTracking = new GridBagConstraints();
 		gbc_chckbxContinueTracking.anchor = GridBagConstraints.NORTHWEST;
 		gbc_chckbxContinueTracking.fill = GridBagConstraints.BOTH;
 		gbc_chckbxContinueTracking.insets = new Insets( 5, 5, 5, 0 );
 		gbc_chckbxContinueTracking.gridx = 1;
-		gbc_chckbxContinueTracking.gridy = 12;
+		gbc_chckbxContinueTracking.gridy = 11;
 		add( chckbxContinueTracking, gbc_chckbxContinueTracking );
-
-		chckbxAllowLinkingIf.addItemListener( ( e ) -> {
-			chckbxLinkIncoming.setEnabled( chckbxAllowLinkingIf.isSelected() );
-			chckbxLinkOutgoing.setEnabled( chckbxAllowLinkingIf.isSelected() );
-			chckbxContinueTracking.setEnabled( chckbxAllowLinkingIf.isSelected() );
-		} );
 
 		final JPanel panelButtons = new JPanel();
 		final GridBagConstraints gbc_panelButtons = new GridBagConstraints();
@@ -269,18 +274,39 @@ public class SemiAutomaticTrackerConfigPanel extends JPanel
 		gbc_panelButtons.insets = new Insets( 5, 5, 0, 0 );
 		gbc_panelButtons.fill = GridBagConstraints.HORIZONTAL;
 		gbc_panelButtons.gridx = 0;
-		gbc_panelButtons.gridy = 13;
+		gbc_panelButtons.gridy = 12;
 		add( panelButtons, gbc_panelButtons );
 		panelButtons.setLayout( new BoxLayout( panelButtons, BoxLayout.X_AXIS ) );
-
-		final JButton btnDefaults = new JButton( "Defaults" );
-		panelButtons.add( btnDefaults );
 
 		final Component horizontalGlue = Box.createHorizontalGlue();
 		panelButtons.add( horizontalGlue );
 
 		final JButton btnTrack = new JButton( "Track" );
 		panelButtons.add( btnTrack );
+
+		final UpdateListener refresher = () -> {
+			comboBox.setSelectedSetupID( editedSettings.getSetupID() );
+			qualityFactor.setCurrentValue( editedSettings.getQualityFactor() );
+			distanceFactor.setCurrentValue( editedSettings.getDistanceFactor() );
+			nTimepoints.setCurrentValue( editedSettings.getnTimepoints() );
+			rdbtnForward.setSelected( editedSettings.isForwardInTime() );
+			rdbtnBackward.setSelected( !editedSettings.isForwardInTime() );
+			chckbxAllowLinkingIf.setSelected( editedSettings.allowLinkingToExisting() );
+			chckbxLinkIncoming.setSelected( editedSettings.allowIfIncomingLinks() );
+			chckbxLinkOutgoing.setSelected( editedSettings.allowIfOutgoingLinks() );
+			chckbxContinueTracking.setSelected( editedSettings.continueIfLinked() );
+			repaint();
+		};
+		final ItemListener disabler = ( e ) -> {
+			chckbxLinkIncoming.setEnabled( chckbxAllowLinkingIf.isSelected() );
+			chckbxLinkOutgoing.setEnabled( chckbxAllowLinkingIf.isSelected() );
+			chckbxContinueTracking.setEnabled( chckbxAllowLinkingIf.isSelected() );
+		};
+
+		refresher.settingsChanged();
+		disabler.itemStateChanged( null );
+		editedSettings.updateListeners().add( refresher );
+		chckbxAllowLinkingIf.addItemListener( disabler );
 	}
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
@@ -1,0 +1,284 @@
+package org.mastodon.trackmate.semiauto.ui;
+
+import static org.mastodon.detection.DetectorKeys.DEFAULT_SETUP_ID;
+import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_ALLOW_LINKING_IF_HAS_INCOMING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_ALLOW_LINKING_IF_HAS_OUTGOING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_ALLOW_LINKING_TO_EXISTING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_CONTINUE_IF_LINK_EXISTS;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_DISTANCE_FACTOR;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_FORWARD_IN_TIME;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_N_TIMEPOINTS;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.DEFAULT_QUALITY_FACTOR;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_ALLOW_LINKING_IF_HAS_INCOMING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_ALLOW_LINKING_IF_HAS_OUTGOING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_ALLOW_LINKING_TO_EXISTING;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_CONTINUE_IF_LINK_EXISTS;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_DISTANCE_FACTOR;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_FORWARD_IN_TIME;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_N_TIMEPOINTS;
+import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_QUALITY_FACTOR;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.mastodon.app.ui.settings.style.Style;
+import org.mastodon.util.Listeners;
+
+public class SemiAutomaticTrackerSettings implements Style< SemiAutomaticTrackerSettings >
+{
+
+	public interface UpdateListener
+	{
+		public void settingsChanged();
+	}
+
+	private final Listeners.List< UpdateListener > updateListeners;
+
+	private String name;
+
+	private int setupID;
+
+	private double qualityFactor;
+
+	private double distanceFactor;
+
+	private int nTimepoints;
+
+	private boolean forwardInTime;
+
+	private boolean allowLinkingToExisting;
+
+	private boolean allowIfIncomingLinks;
+
+	private boolean allowIfOutgoingLinks;
+
+	private boolean continueIfLinked;
+
+	private static final SemiAutomaticTrackerSettings defSats;
+	static
+	{
+		defSats = new SemiAutomaticTrackerSettings();
+		defSats.setupID = DEFAULT_SETUP_ID;
+		defSats.qualityFactor = DEFAULT_QUALITY_FACTOR;
+		defSats.distanceFactor = DEFAULT_DISTANCE_FACTOR;
+		defSats.nTimepoints = DEFAULT_N_TIMEPOINTS;
+		defSats.forwardInTime = DEFAULT_FORWARD_IN_TIME;
+		defSats.allowLinkingToExisting = DEFAULT_ALLOW_LINKING_TO_EXISTING;
+		defSats.allowIfIncomingLinks = DEFAULT_ALLOW_LINKING_IF_HAS_INCOMING;
+		defSats.allowIfOutgoingLinks = DEFAULT_ALLOW_LINKING_IF_HAS_OUTGOING;
+		defSats.continueIfLinked = DEFAULT_CONTINUE_IF_LINK_EXISTS;
+		defSats.name = "Default";
+	}
+
+	public static SemiAutomaticTrackerSettings defaultSettings()
+	{
+		return defSats;
+	}
+
+	private SemiAutomaticTrackerSettings()
+	{
+		this.updateListeners = new Listeners.SynchronizedList<>();
+	}
+
+	private void notifyListeners()
+	{
+		for ( final UpdateListener l : updateListeners.list )
+			l.settingsChanged();
+	}
+
+	public Listeners< UpdateListener > updateListeners()
+	{
+		return updateListeners;
+	}
+
+	public void set( final SemiAutomaticTrackerSettings stas )
+	{
+		this.name = stas.name;
+		this.setupID = stas.setupID;
+		this.distanceFactor = stas.distanceFactor;
+		this.qualityFactor = stas.qualityFactor;
+		this.nTimepoints = stas.nTimepoints;
+		this.forwardInTime = stas.forwardInTime;
+		this.allowLinkingToExisting = stas.allowLinkingToExisting;
+		this.allowIfIncomingLinks = stas.allowIfIncomingLinks;
+		this.allowIfOutgoingLinks = stas.allowIfOutgoingLinks;
+		this.continueIfLinked = stas.continueIfLinked;
+		notifyListeners();
+	}
+
+	public Map< String, Object > getAsSettingsMap()
+	{
+		final Map< String, Object > map = new HashMap<>();
+		map.put( KEY_SETUP_ID, Integer.valueOf( setupID ) );
+		map.put( KEY_DISTANCE_FACTOR, Double.valueOf( distanceFactor ) );
+		map.put( KEY_QUALITY_FACTOR, Double.valueOf( qualityFactor ) );
+		map.put( KEY_N_TIMEPOINTS, Integer.valueOf( nTimepoints ) );
+		map.put( KEY_FORWARD_IN_TIME, Boolean.valueOf( forwardInTime ) );
+		map.put( KEY_ALLOW_LINKING_TO_EXISTING, Boolean.valueOf( allowLinkingToExisting ) );
+		map.put( KEY_ALLOW_LINKING_IF_HAS_INCOMING, Boolean.valueOf( allowIfIncomingLinks ) );
+		map.put( KEY_ALLOW_LINKING_IF_HAS_OUTGOING, Boolean.valueOf( allowIfOutgoingLinks ) );
+		map.put( KEY_CONTINUE_IF_LINK_EXISTS, Boolean.valueOf( allowIfIncomingLinks ) );
+		return map;
+	}
+
+	public int getSetupID()
+	{
+		return setupID;
+	}
+
+	public void setSetupID( final int setupID )
+	{
+		if ( this.setupID != setupID )
+		{
+			this.setupID = setupID;
+			notifyListeners();
+		}
+	}
+
+	public double getQualityFactor()
+	{
+		return qualityFactor;
+	}
+
+	public void setQualityFactor( final double qualityFactor )
+	{
+		if ( this.qualityFactor != qualityFactor )
+		{
+			this.qualityFactor = qualityFactor;
+			notifyListeners();
+		}
+	}
+
+	public double getDistanceFactor()
+	{
+		return distanceFactor;
+	}
+
+	public void setDistanceFactor( final double distanceFactor )
+	{
+		if ( this.distanceFactor != distanceFactor )
+		{
+			this.distanceFactor = distanceFactor;
+			notifyListeners();
+		}
+	}
+
+	public int getnTimepoints()
+	{
+		return nTimepoints;
+	}
+
+	public void setNTimepoints( final int nTimepoints )
+	{
+		if ( this.nTimepoints != nTimepoints )
+		{
+			this.nTimepoints = nTimepoints;
+			notifyListeners();
+		}
+	}
+
+	public boolean isForwardInTime()
+	{
+		return forwardInTime;
+	}
+
+	public void setForwardInTime( final boolean forwardInTime )
+	{
+		if ( this.forwardInTime != forwardInTime )
+		{
+			this.forwardInTime = forwardInTime;
+			notifyListeners();
+		}
+	}
+
+	public boolean allowLinkingToExisting()
+	{
+		return allowLinkingToExisting;
+	}
+
+	public void setAllowLinkingToExisting( final boolean allowLinkingToExisting )
+	{
+		if ( this.allowLinkingToExisting != allowLinkingToExisting )
+		{
+			this.allowLinkingToExisting = allowLinkingToExisting;
+			notifyListeners();
+		}
+	}
+
+	public boolean allowIfIncomingLinks()
+	{
+		return allowIfIncomingLinks;
+	}
+
+	public void setAllowIfIncomingLinks( final boolean allowIfIncomingLinks )
+	{
+		if ( this.allowIfIncomingLinks != allowIfIncomingLinks )
+		{
+			this.allowIfIncomingLinks = allowIfIncomingLinks;
+			notifyListeners();
+		}
+	}
+
+	public boolean allowIfOutgoingLinks()
+	{
+		return allowIfOutgoingLinks;
+	}
+
+	public void setAllowIfOutgoingLinks( final boolean allowIfOutgoingLinks )
+	{
+		if ( this.allowIfOutgoingLinks != allowIfOutgoingLinks )
+		{
+			this.allowIfOutgoingLinks = allowIfOutgoingLinks;
+			notifyListeners();
+		}
+	}
+
+	public boolean continueIfLinked()
+	{
+		return continueIfLinked;
+	}
+
+	public void setContinueIfLinked( final boolean continueIfLinked )
+	{
+		if ( this.continueIfLinked != continueIfLinked )
+		{
+			this.continueIfLinked = continueIfLinked;
+			notifyListeners();
+		}
+	}
+
+	@Override
+	public SemiAutomaticTrackerSettings copy()
+	{
+		return copy( null );
+	}
+
+	@Override
+	public SemiAutomaticTrackerSettings copy( final String newName )
+	{
+		final SemiAutomaticTrackerSettings sats = new SemiAutomaticTrackerSettings();
+		sats.set( this );
+		if ( name != null )
+			sats.setName( name );
+		return sats;
+	}
+
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+
+	@Override
+	public void setName( final String name )
+	{
+		if ( !Objects.equals( this.name, name ) )
+		{
+			this.name = name;
+			notifyListeners();
+		}
+	}
+
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
@@ -256,7 +256,7 @@ public class SemiAutomaticTrackerSettings implements Style< SemiAutomaticTracker
 	}
 
 	@Override
-	public SemiAutomaticTrackerSettings copy( final String newName )
+	public SemiAutomaticTrackerSettings copy( final String name )
 	{
 		final SemiAutomaticTrackerSettings sats = new SemiAutomaticTrackerSettings();
 		sats.set( this );

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
@@ -19,7 +19,10 @@ import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_FORWA
 import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_N_TIMEPOINTS;
 import static org.mastodon.trackmate.semiauto.SemiAutomaticTrackerKeys.KEY_QUALITY_FACTOR;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -69,12 +72,37 @@ public class SemiAutomaticTrackerSettings implements Style< SemiAutomaticTracker
 		defSats.allowIfIncomingLinks = DEFAULT_ALLOW_LINKING_IF_HAS_INCOMING;
 		defSats.allowIfOutgoingLinks = DEFAULT_ALLOW_LINKING_IF_HAS_OUTGOING;
 		defSats.continueIfLinked = DEFAULT_CONTINUE_IF_LINK_EXISTS;
-		defSats.name = "Default";
+		defSats.name = "Forward";
+	}
+
+	private static final SemiAutomaticTrackerSettings backSats;
+	static
+	{
+		backSats = new SemiAutomaticTrackerSettings();
+		backSats.setupID = DEFAULT_SETUP_ID;
+		backSats.qualityFactor = DEFAULT_QUALITY_FACTOR;
+		backSats.distanceFactor = DEFAULT_DISTANCE_FACTOR;
+		backSats.nTimepoints = 100 * DEFAULT_N_TIMEPOINTS;
+		backSats.forwardInTime = Boolean.valueOf( false );
+		backSats.allowLinkingToExisting = Boolean.valueOf( true );
+		backSats.allowIfIncomingLinks = Boolean.valueOf( true );
+		backSats.allowIfOutgoingLinks = Boolean.valueOf( true );
+		backSats.continueIfLinked = Boolean.valueOf( false );
+		backSats.name = "Backtracking";
 	}
 
 	public static SemiAutomaticTrackerSettings defaultSettings()
 	{
 		return defSats;
+	}
+
+
+	public static List< SemiAutomaticTrackerSettings > defaults()
+	{
+		final List< SemiAutomaticTrackerSettings > df = new ArrayList<>( 2 );
+		df.add( defSats );
+		df.add( backSats );
+		return Collections.unmodifiableList( df );
 	}
 
 	private SemiAutomaticTrackerSettings()
@@ -280,5 +308,4 @@ public class SemiAutomaticTrackerSettings implements Style< SemiAutomaticTracker
 			notifyListeners();
 		}
 	}
-
 }

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettings.java
@@ -147,7 +147,7 @@ public class SemiAutomaticTrackerSettings implements Style< SemiAutomaticTracker
 		map.put( KEY_ALLOW_LINKING_TO_EXISTING, Boolean.valueOf( allowLinkingToExisting ) );
 		map.put( KEY_ALLOW_LINKING_IF_HAS_INCOMING, Boolean.valueOf( allowIfIncomingLinks ) );
 		map.put( KEY_ALLOW_LINKING_IF_HAS_OUTGOING, Boolean.valueOf( allowIfOutgoingLinks ) );
-		map.put( KEY_CONTINUE_IF_LINK_EXISTS, Boolean.valueOf( allowIfIncomingLinks ) );
+		map.put( KEY_CONTINUE_IF_LINK_EXISTS, Boolean.valueOf( continueIfLinked ) );
 		return map;
 	}
 

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsIO.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsIO.java
@@ -82,7 +82,7 @@ public class SemiAutomaticTrackerSettingsIO
 			mapping.put( "allowIfOutgoingLinks", s.allowIfOutgoingLinks() );
 			mapping.put( "continueIfLinked", s.continueIfLinked() );
 
-			final Node node = representMapping( getTag(), mapping, getDefaultFlowStyle() );
+			final Node node = representMapping( getTag(), mapping, false );
 			return node;
 		}
 	}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsIO.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsIO.java
@@ -1,0 +1,127 @@
+package org.mastodon.trackmate.semiauto.ui;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mastodon.revised.io.yaml.AbstractWorkaroundConstruct;
+import org.mastodon.revised.io.yaml.WorkaroundConstructor;
+import org.mastodon.revised.io.yaml.WorkaroundRepresent;
+import org.mastodon.revised.io.yaml.WorkaroundRepresenter;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Facilities to dump / load {@link SemiAutomaticTrackerSettings} to / from a YAML file.
+ *
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class SemiAutomaticTrackerSettingsIO
+{
+	private static class SemiAutomaticTrackerSettingsRepresenter extends WorkaroundRepresenter
+	{
+		public SemiAutomaticTrackerSettingsRepresenter()
+		{
+			putRepresent( new RepresentSemiAutomaticTrackerSettings( this ) );
+		}
+	}
+
+	private static class SemiAutomaticTrackerSettingsConstructor extends WorkaroundConstructor
+	{
+		public SemiAutomaticTrackerSettingsConstructor()
+		{
+			super( Object.class );
+			putConstruct( new ConstructSemiAutomaticTrackerSettings( this ) );
+		}
+	}
+
+	/**
+	 * Returns a YAML instance that can dump / load a collection of
+	 * {@link SemiAutomaticTrackerSettings} to / from a .yaml file.
+	 *
+	 * @return a new YAML instance.
+	 */
+	static Yaml createYaml()
+	{
+		final DumperOptions dumperOptions = new DumperOptions();
+		final Representer representer = new SemiAutomaticTrackerSettingsRepresenter();
+		final Constructor constructor = new SemiAutomaticTrackerSettingsConstructor();
+		final Yaml yaml = new Yaml( constructor, representer, dumperOptions );
+		return yaml;
+	}
+
+	private static final Tag SEMIAUTOTRACKERSETTINGS_TAG = new Tag( "!semiautomatictrackersettings" );
+
+	private static class RepresentSemiAutomaticTrackerSettings extends WorkaroundRepresent
+	{
+		public RepresentSemiAutomaticTrackerSettings( final WorkaroundRepresenter r )
+		{
+			super( r, SEMIAUTOTRACKERSETTINGS_TAG, SemiAutomaticTrackerSettings.class );
+		}
+
+		@Override
+		public Node representData( final Object data )
+		{
+			final SemiAutomaticTrackerSettings s = ( SemiAutomaticTrackerSettings ) data;
+			final Map< String, Object > mapping = new LinkedHashMap< >();
+
+			mapping.put( "name", s.getName() );
+
+			mapping.put( "setupID", s.getSetupID() );
+			mapping.put( "qualityFactor", s.getQualityFactor() );
+			mapping.put( "distanceFactor", s.getDistanceFactor() );
+			mapping.put( "nTimepoints", s.getnTimepoints() );
+			mapping.put( "forwardInTime", s.isForwardInTime() );
+			mapping.put( "allowLinkingToExisting", s.allowLinkingToExisting() );
+			mapping.put( "allowIfIncomingLinks", s.allowIfIncomingLinks() );
+			mapping.put( "allowIfOutgoingLinks", s.allowIfOutgoingLinks() );
+			mapping.put( "continueIfLinked", s.continueIfLinked() );
+
+			final Node node = representMapping( getTag(), mapping, getDefaultFlowStyle() );
+			return node;
+		}
+	}
+
+	private static class ConstructSemiAutomaticTrackerSettings extends AbstractWorkaroundConstruct
+	{
+		public ConstructSemiAutomaticTrackerSettings( final WorkaroundConstructor c )
+		{
+			super( c, SEMIAUTOTRACKERSETTINGS_TAG );
+		}
+
+		@Override
+		public Object construct( final Node node )
+		{
+			try
+			{
+				final Map< Object, Object > mapping = constructMapping( ( MappingNode  ) node );
+				final String name = ( String ) mapping.get( "name" );
+				final SemiAutomaticTrackerSettings s = SemiAutomaticTrackerSettings.defaultSettings().copy( name );
+
+				s.setName( ( String ) mapping.get( "name") );
+
+				s.setSetupID( ( int ) mapping.get( "setupID" ) );
+				s.setQualityFactor( ( double ) mapping.get( "qualityFactor" ) );
+				s.setDistanceFactor( ( double ) mapping.get( "distanceFactor" ) );
+				s.setNTimepoints( ( int ) mapping.get( "nTimepoints" ) );
+				s.setForwardInTime( ( boolean ) mapping.get( "forwardInTime" ) );
+				s.setAllowLinkingToExisting( ( boolean ) mapping.get( "allowLinkingToExisting" ) );
+				s.setAllowIfIncomingLinks( ( boolean ) mapping.get( "allowIfIncomingLinks" ) );
+				s.setAllowIfOutgoingLinks( ( boolean ) mapping.get( "allowIfOutgoingLinks" ) );
+				s.setContinueIfLinked( ( boolean ) mapping.get( "continueIfLinked" ) );
+
+				return s;
+			}
+			catch( final Exception e )
+			{
+				e.printStackTrace();
+			}
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsManager.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsManager.java
@@ -1,0 +1,130 @@
+package org.mastodon.trackmate.semiauto.ui;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.mastodon.app.ui.settings.style.AbstractStyleManager;
+import org.yaml.snakeyaml.Yaml;
+
+public class SemiAutomaticTrackerSettingsManager extends AbstractStyleManager< SemiAutomaticTrackerSettingsManager, SemiAutomaticTrackerSettings >
+{
+
+	private static final String SETTINGS_FILE = System.getProperty( "user.home" ) + "/.mastodon/semiautomatictrackersettings.yaml";
+
+	private final SemiAutomaticTrackerSettings forwardDefaultSettings;
+
+	private final SemiAutomaticTrackerSettings.UpdateListener updateForwardDefaultListeners;
+
+	public SemiAutomaticTrackerSettingsManager()
+	{
+		this( true );
+	}
+
+	public SemiAutomaticTrackerSettingsManager( final boolean loadSettings )
+	{
+		forwardDefaultSettings = SemiAutomaticTrackerSettings.defaultSettings().copy();
+		updateForwardDefaultListeners = () -> forwardDefaultSettings.set( defaultStyle );
+		defaultStyle.updateListeners().add( updateForwardDefaultListeners );
+		if ( loadSettings )
+			loadStyles();
+	}
+
+	/**
+	 * Returns a final {@link SemiAutomaticTrackerSettings} instance that always has the same
+	 * properties as the default style.
+	 */
+	public SemiAutomaticTrackerSettings getForwardDefaultStyle()
+	{
+		return forwardDefaultSettings;
+	}
+
+	@Override
+	public void saveStyles()
+	{
+		saveStyles( SETTINGS_FILE );
+	}
+
+	public void saveStyles( final String filename )
+	{
+		try
+		{
+			new File( filename ).getParentFile().mkdirs();
+			final FileWriter output = new FileWriter( filename );
+			final Yaml yaml = SemiAutomaticTrackerSettingsIO.createYaml();
+			final ArrayList< Object > objects = new ArrayList<>();
+			objects.add( defaultStyle.getName() );
+			objects.addAll( userStyles );
+			yaml.dumpAll( objects.iterator(), output );
+			output.close();
+		}
+		catch ( final IOException e )
+		{
+			e.printStackTrace();
+		}
+	}
+
+	public void loadStyles()
+	{
+		loadStyles( SETTINGS_FILE );
+	}
+
+	public void loadStyles( final String filename )
+	{
+		userStyles.clear();
+		final Set< String > names = builtinStyles.stream().map( SemiAutomaticTrackerSettings::getName ).collect( Collectors.toSet() );
+		try
+		{
+			final FileReader input = new FileReader( filename );
+			final Yaml yaml = SemiAutomaticTrackerSettingsIO.createYaml();
+			final Iterable< Object > objs = yaml.loadAll( input );
+			String defaultStyleName = null;
+			for ( final Object obj : objs )
+			{
+				if ( obj instanceof String )
+				{
+					defaultStyleName = ( String ) obj;
+				}
+				else if ( obj instanceof SemiAutomaticTrackerSettings )
+				{
+					final SemiAutomaticTrackerSettings ts = ( SemiAutomaticTrackerSettings ) obj;
+					if ( null != ts )
+					{
+						// sanity check: settings names must be unique
+						if ( names.add( ts.getName() ) )
+							userStyles.add( ts );
+						else
+							System.out.println( "Discarded settings with duplicate name \"" + ts.getName() + "\"." );
+					}
+				}
+			}
+			setDefaultStyle( styleForName( defaultStyleName ).orElseGet( () -> builtinStyles.get( 0 ) ) );
+		}
+		catch ( final FileNotFoundException e )
+		{
+			System.out.println( "SemiAutomaticTrackerSettings file " + filename + " not found. Using builtin settings." );
+		}
+	}
+
+	@Override
+	public synchronized void setDefaultStyle( final SemiAutomaticTrackerSettings renderSettings )
+	{
+		defaultStyle.updateListeners().remove( updateForwardDefaultListeners );
+		defaultStyle = renderSettings;
+		forwardDefaultSettings.set( defaultStyle );
+		defaultStyle.updateListeners().add( updateForwardDefaultListeners );
+	}
+
+	@Override
+	protected List< SemiAutomaticTrackerSettings > loadBuiltinStyles()
+	{
+		return Arrays.asList( new SemiAutomaticTrackerSettings[] { SemiAutomaticTrackerSettings.defaultSettings() } );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsManager.java
+++ b/src/main/java/org/mastodon/trackmate/semiauto/ui/SemiAutomaticTrackerSettingsManager.java
@@ -6,7 +6,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,8 +37,10 @@ public class SemiAutomaticTrackerSettingsManager extends AbstractStyleManager< S
 	}
 
 	/**
-	 * Returns a final {@link SemiAutomaticTrackerSettings} instance that always has the same
-	 * properties as the default style.
+	 * Returns a final {@link SemiAutomaticTrackerSettings} instance that always has
+	 * the same properties as the default style.
+	 * 
+	 * @return the forward settings.
 	 */
 	public SemiAutomaticTrackerSettings getForwardDefaultStyle()
 	{
@@ -125,6 +126,6 @@ public class SemiAutomaticTrackerSettingsManager extends AbstractStyleManager< S
 	@Override
 	protected List< SemiAutomaticTrackerSettings > loadBuiltinStyles()
 	{
-		return Arrays.asList( new SemiAutomaticTrackerSettings[] { SemiAutomaticTrackerSettings.defaultSettings() } );
+		return SemiAutomaticTrackerSettings.defaults();
 	}
 }

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/DetectionSequence.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/DetectionSequence.java
@@ -1,10 +1,5 @@
 package org.mastodon.trackmate.ui.wizard;
 
-import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
-import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
-import static org.mastodon.detection.DetectorKeys.KEY_ROI;
-import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +92,8 @@ public class DetectionSequence implements WizardSequence
 	private SpotDetectorDescriptor getConfigDescriptor()
 	{
 		final Class< ? extends SpotDetectorOp > detectorClass = trackmate.getSettings().values.getDetector();
+
+
 		final List< String > linkerPanelNames = descriptorProvider.getNames();
 		for ( final String key : linkerPanelNames )
 		{
@@ -109,16 +106,16 @@ public class DetectionSequence implements WizardSequence
 				previousDetectorPanel = detectorConfigDescriptor;
 				if ( detectorConfigDescriptor.getContext() == null )
 					windowManager.getContext().inject( detectorConfigDescriptor );
+
+				/*
+				 * Copy as much settings as we can to the potentially new config descriptor.
+				 */
+				final Map< String, Object > oldSettings = new HashMap<>( trackmate.getSettings().values.getDetectorSettings() );
 				final Map< String, Object > defaultSettings = detectorConfigDescriptor.getDefaultSettings();
-
-				// Pass the old ROI to the new settings.
-				final Map< String, Object > oldSettings = trackmate.getSettings().values.getDetectorSettings();
-				defaultSettings.put( KEY_MAX_TIMEPOINT, oldSettings.get( KEY_MAX_TIMEPOINT ) );
-				defaultSettings.put( KEY_MIN_TIMEPOINT, oldSettings.get( KEY_MIN_TIMEPOINT ) );
-				defaultSettings.put( KEY_ROI, oldSettings.get( KEY_ROI ) );
-				defaultSettings.put( KEY_SETUP_ID, oldSettings.get( KEY_SETUP_ID ) );
-
+				for ( final String skey : defaultSettings.keySet() )
+					defaultSettings.put( skey, oldSettings.get( skey ) );
 				trackmate.getSettings().detectorSettings( defaultSettings );
+
 				detectorConfigDescriptor.setTrackMate( trackmate );
 				detectorConfigDescriptor.setWindowManager( windowManager );
 				detectorConfigDescriptor.getPanelComponent().setSize( chooseDetectorDescriptor.getPanelComponent().getSize() );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/LinkingSequence.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/LinkingSequence.java
@@ -1,8 +1,5 @@
 package org.mastodon.trackmate.ui.wizard;
 
-import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
-import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,10 +96,14 @@ public class LinkingSequence implements WizardSequence
 					windowManager.getContext().inject( linkerConfigDescriptor );
 				final Map< String, Object > defaultSettings = linkerConfigDescriptor.getDefaultSettings();
 
-				// Pass the old ROI to the new settings.
+				// Pass as much parameter as we can from the old settings.
 				final Map< String, Object > oldSettings = trackmate.getSettings().values.getLinkerSettings();
-				defaultSettings.put( KEY_MAX_TIMEPOINT, oldSettings.get( KEY_MAX_TIMEPOINT ) );
-				defaultSettings.put( KEY_MIN_TIMEPOINT, oldSettings.get( KEY_MIN_TIMEPOINT ) );
+				for ( final String pkey : defaultSettings.keySet() )
+				{
+					if ( !oldSettings.containsKey( pkey ) )
+						continue;
+					defaultSettings.put( pkey, oldSettings.get( pkey ) );
+				}
 
 				trackmate.getSettings().linkerSettings( defaultSettings );
 				linkerConfigDescriptor.setTrackMate( trackmate );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardController.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardController.java
@@ -164,6 +164,8 @@ public class WizardController implements WindowListener
 		wizardPanel.btnNext.setVisible( sequence.hasNext() );
 		wizardPanel.btnFinish.setVisible( !sequence.hasNext() );
 		wizardPanel.transition( to, from, direction );
+		if ( !sequence.hasNext() )
+			wizardPanel.btnFinish.requestFocusInWindow();
 	}
 
 	private Action getNextAction()

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardDetectionPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardDetectionPlugin.java
@@ -16,6 +16,8 @@ public class WizardDetectionPlugin extends WizardPlugin
 
 	private static final String[] RUN_WIZARD_KEYS = new String[] { "not mapped" };
 
+	private static final Settings settings = new Settings();
+
 	public WizardDetectionPlugin()
 	{
 		super( RUN_WIZARD, "Detection...", "Plugins > TrackMate", RUN_WIZARD_KEYS );
@@ -32,10 +34,9 @@ public class WizardDetectionPlugin extends WizardPlugin
 		 * work, but requires additional casting when instantiation ops.
 		 */
 		final SpimDataMinimal spimData = ( SpimDataMinimal ) appModel.getSharedBdvData().getSpimData();
-		final Settings settings = new Settings().spimData( spimData );
+		settings.spimData( spimData );
 		final TrackMate trackmate = new TrackMate( settings, appModel.getModel() );
 		getContext().inject( trackmate );
-
 		return new DetectionSequence( trackmate, windowManager, wizard.getLogService() );
 	}
 }

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardLinkingPlugin.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardLinkingPlugin.java
@@ -27,6 +27,15 @@ public class WizardLinkingPlugin extends WizardPlugin
 
 	private static final String MENU_PATH = "Plugins > TrackMate";
 
+	private final static Settings settings = new Settings();
+	static
+	{
+		final Map< String, Object > defaultLinkerSettings = LinkingUtils.getDefaultLAPSettingsMap();
+		final Map< String, Object > defaultDetectorSettings = DetectionUtil.getDefaultDetectorSettingsMap();
+		settings.detectorSettings( defaultDetectorSettings )
+				.linkerSettings( defaultLinkerSettings );
+	}
+
 	public WizardLinkingPlugin()
 	{
 		super( ACTION_NAME, COMMAND_NAME, MENU_PATH, KEYSTROKES );
@@ -41,17 +50,14 @@ public class WizardLinkingPlugin extends WizardPlugin
 		final int tmax = windowManager.getAppModel().getMaxTimepoint();
 		final int tmin = windowManager.getAppModel().getMinTimepoint();
 
-		final Map< String, Object > defaultLinkerSettings = LinkingUtils.getDefaultLAPSettingsMap();
-		defaultLinkerSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( tmin ) );
-		defaultLinkerSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( tmax ) );
-		final Map< String, Object > defaultDetectorSettings = DetectionUtil.getDefaultDetectorSettingsMap();
-		defaultDetectorSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( tmin ) );
-		defaultDetectorSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( tmax ) );
+		final Map< String, Object > linkerSettings = settings.values.getLinkerSettings();
+		linkerSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( tmin ) );
+		linkerSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( tmax ) );
+		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+		detectorSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( tmin ) );
+		detectorSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( tmax ) );
 
-		final Settings settings = new Settings()
-				.spimData( spimData )
-				.linkerSettings( defaultLinkerSettings )
-				.detectorSettings( defaultDetectorSettings );
+		settings.spimData( spimData );
 		final TrackMate trackmate = new TrackMate( settings, appModel.getModel() );
 		getContext().inject( trackmate );
 

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/WizardUtils.java
@@ -1,0 +1,154 @@
+package org.mastodon.trackmate.ui.wizard;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.mastodon.adapter.FocusModelAdapter;
+import org.mastodon.adapter.HighlightModelAdapter;
+import org.mastodon.adapter.RefBimap;
+import org.mastodon.adapter.SelectionModelAdapter;
+import org.mastodon.graph.GraphIdBimap;
+import org.mastodon.grouping.GroupManager;
+import org.mastodon.model.DefaultFocusModel;
+import org.mastodon.model.DefaultHighlightModel;
+import org.mastodon.model.DefaultSelectionModel;
+import org.mastodon.revised.bdv.BigDataViewerMamut;
+import org.mastodon.revised.bdv.NavigationActionsMamut;
+import org.mastodon.revised.bdv.SharedBigDataViewerData;
+import org.mastodon.revised.bdv.ViewerFrameMamut;
+import org.mastodon.revised.bdv.ViewerPanelMamut;
+import org.mastodon.revised.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayEdgeWrapper;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayGraphWrapper;
+import org.mastodon.revised.bdv.overlay.wrap.OverlayVertexWrapper;
+import org.mastodon.revised.mamut.KeyConfigContexts;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.BoundingSphereRadiusStatistics;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.ModelGraph;
+import org.mastodon.revised.model.mamut.ModelOverlayProperties;
+import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.revised.ui.keymap.Keymap;
+import org.mastodon.revised.ui.keymap.KeymapManager;
+import org.scijava.Context;
+import org.scijava.log.LogService;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.Behaviours;
+
+import bdv.tools.InitializeViewerState;
+import mpicbg.spim.data.SpimDataException;
+
+/**
+ * A collection of static utilities related to running Msatodon with the wizard
+ * framework in this package.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class WizardUtils
+{
+
+	/**
+	 * The name used as frame title for the detection preview frame created by
+	 * {@link #preview(WindowManager, ViewerFrameMamut, Model, LogService)}
+	 * method.
+	 */
+	public static String PREVIEW_DETECTION_FRAME_NAME = "Preview detection";
+
+	/**
+	 * Creates or shows a BDV window suitable to be used as a preview detection
+	 * frame.
+	 * 
+	 * @param viewFrame
+	 *            the viewer frame, potentially created from a previous call to
+	 *            this method. If <code>null</code> a new one will be created
+	 *            and returned. If not <code>null</code>, the window will be
+	 *            brought up front.
+	 * @param shared
+	 *            the {@link SharedBigDataViewerData} from which the image data
+	 *            to show is taken.
+	 * @param model
+	 *            the model to display in the preview frame. The preview window
+	 *            will be notified of changes in this model, and display them.
+	 * @return a new {@link ViewerFrameMamut} or the non-<code>null</code> one
+	 *         passed in argument.
+	 */
+	public static final ViewerFrameMamut preview( ViewerFrameMamut viewFrame, final SharedBigDataViewerData shared, final Model model )
+	{
+		if ( null == viewFrame || !viewFrame.isShowing() )
+		{
+			final ModelGraph graph = model.getGraph();
+			final GraphIdBimap< Spot, Link > graphIdBimap = model.getGraphIdBimap();
+			final String[] keyConfigContexts = new String[] { KeyConfigContexts.BIGDATAVIEWER };
+			final Keymap keymap = new KeymapManager().getForwardDefaultKeymap();
+
+			final BigDataViewerMamut bdv = new BigDataViewerMamut( shared, "Preview detection", new GroupManager( 0 ).createGroupHandle() );
+			final ViewerPanelMamut viewer = bdv.getViewer();
+			InitializeViewerState.initTransform( viewer );
+			viewFrame = bdv.getViewerFrame();
+
+			final BoundingSphereRadiusStatistics radiusStats = new BoundingSphereRadiusStatistics( model );
+			final OverlayGraphWrapper< Spot, Link > viewGraph = new OverlayGraphWrapper< Spot, Link >(
+					graph,
+					graphIdBimap,
+					model.getSpatioTemporalIndex(),
+					graph.getLock(),
+					new ModelOverlayProperties( graph, radiusStats ) );
+			final RefBimap< Spot, OverlayVertexWrapper< Spot, Link > > vertexMap = viewGraph.getVertexMap();
+			final RefBimap< Link, OverlayEdgeWrapper< Spot, Link > > edgeMap = viewGraph.getEdgeMap();
+
+			final DefaultHighlightModel< Spot, Link > highlightModel = new DefaultHighlightModel<>( graphIdBimap );
+			final HighlightModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > highlightModelAdapter =
+					new HighlightModelAdapter<>( highlightModel, vertexMap, edgeMap );
+
+			final DefaultFocusModel< Spot, Link > focusModel = new DefaultFocusModel<>( graphIdBimap );
+			final FocusModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > focusModelAdapter =
+					new FocusModelAdapter<>( focusModel, vertexMap, edgeMap );
+
+			final DefaultSelectionModel< Spot, Link > selectionModel = new DefaultSelectionModel<>( graph, graphIdBimap );
+			final SelectionModelAdapter< Spot, Link, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > selectionModelAdapter =
+					new SelectionModelAdapter<>( selectionModel, vertexMap, edgeMap );
+
+			final OverlayGraphRenderer< OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > tracksOverlay = new OverlayGraphRenderer<>(
+					viewGraph,
+					highlightModelAdapter,
+					focusModelAdapter,
+					selectionModelAdapter );
+			viewer.getDisplay().addOverlayRenderer( tracksOverlay );
+			viewer.addRenderTransformListener( tracksOverlay );
+			viewer.addTimePointListener( tracksOverlay );
+			graph.addGraphChangeListener( () -> viewer.getDisplay().repaint() );
+
+			final Actions viewActions = new Actions( keymap.getConfig(), keyConfigContexts );
+			viewActions.install( viewFrame.getKeybindings(), "view" );
+			final Behaviours viewBehaviours = new Behaviours( keymap.getConfig(), keyConfigContexts );
+			viewBehaviours.install( viewFrame.getTriggerbindings(), "view" );
+
+			NavigationActionsMamut.install( viewActions, viewer );
+			viewer.getTransformEventHandler().install( viewBehaviours );
+
+			viewFrame.setVisible( true );
+		}
+		viewFrame.toFront();
+		return viewFrame;
+	}
+
+	private WizardUtils()
+	{}
+
+	public static void main( final String[] args ) throws IOException, SpimDataException
+	{
+		final Context context = new Context();
+		final WindowManager windowManager = new WindowManager( context );
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+		windowManager.getProjectManager().open( project );
+
+		final Model model = new Model();
+		model.getGraph().addVertex().init( 0, new double[] { 50., 50., 50., }, 20. );
+
+		preview( null, windowManager.getAppModel().getSharedBdvData(), model );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
@@ -24,7 +24,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JFormattedTextField;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -264,7 +263,6 @@ public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
 		else
 			threshold = ( double ) objThreshold;
 
-
 		DetectionBehavior detectionBehavior = DetectionBehavior.ADD;
 		final String addBehavior = ( String ) detectorSettings.get( KEY_ADD_BEHAVIOR );
 		if ( null != addBehavior )
@@ -423,16 +421,5 @@ public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
 		{
 			SwingUtilities.invokeLater( () -> textField.selectAll() );
 		}
-	}
-
-	public static void main( final String[] args )
-	{
-		final AdvancedDoGDetectorDescriptor desc = new AdvancedDoGDetectorDescriptor();
-
-		final JFrame frame = new JFrame( "Test" );
-		frame.getContentPane().add( desc.targetPanel );
-		frame.setSize( 300, 600 );
-		desc.aboutToDisplayPanel();
-		frame.setVisible( true );
 	}
 }

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
@@ -32,7 +32,7 @@ import javax.swing.SwingUtilities;
 import org.jfree.chart.ChartPanel;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
@@ -137,7 +137,7 @@ public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		final SpimDataMinimal spimData = settings.values.getSpimData();
 		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
-		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final double minSizePixel = DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
 		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
 		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
 		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/AdvancedDoGDetectorDescriptor.java
@@ -1,0 +1,438 @@
+package org.mastodon.trackmate.ui.wizard.descriptors;
+
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
+import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
+import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
+import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
+import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
+
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.jfree.chart.ChartPanel;
+import org.mastodon.detection.DetectionUtil;
+import org.mastodon.detection.DetectorKeys;
+import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
+import org.mastodon.detection.mamut.SpotDetectorOp;
+import org.mastodon.revised.bdv.SharedBigDataViewerData;
+import org.mastodon.revised.bdv.ViewerFrameMamut;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.trackmate.Settings;
+import org.mastodon.trackmate.TrackMate;
+import org.mastodon.trackmate.ui.wizard.Wizard;
+import org.mastodon.trackmate.ui.wizard.util.WizardUtils;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.util.Affine3DHelpers;
+import mpicbg.spim.data.generic.sequence.BasicMultiResolutionImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import net.imagej.ops.OpService;
+import net.imglib2.realtransform.AffineTransform3D;
+
+@Plugin( type = SpotDetectorDescriptor.class, name = "Advanced DoG detector configuration descriptor" )
+public class AdvancedDoGDetectorDescriptor extends SpotDetectorDescriptor
+{
+
+	public static final String IDENTIFIER = "Configure Advanced DoG detector";
+
+	private static final Icon PREVIEW_ICON = new ImageIcon( Wizard.class.getResource( "led-icon-eye-green.png" ) );
+
+	private static final NumberFormat FORMAT = new DecimalFormat( "0.0" );
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private OpService ops;
+
+	private Settings settings;
+
+	private WindowManager windowManager;
+
+	private ChartPanel chartPanel;
+
+	private ViewerFrameMamut viewFrame;
+
+	private final Model localModel;
+
+	public AdvancedDoGDetectorDescriptor()
+	{
+		this.panelIdentifier = IDENTIFIER;
+		this.targetPanel = new AdvancedDoGDetectorPanel();
+		/*
+		 * Use a separate model for the preview. We do not want to touch the
+		 * existing model.
+		 */
+		this.localModel = new Model();
+	}
+
+	/**
+	 * Update the settings field of this descriptor with the values set on the
+	 * GUI.
+	 */
+	private void grabSettings()
+	{
+		if ( null == settings )
+			return;
+
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
+		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, ( ( DetectionBehavior ) panel.behaviorCB.getSelectedItem() ).name() );
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	@Override
+	public Collection< Class< ? extends SpotDetectorOp > > getTargetClasses()
+	{
+		final Collection b = Collections.unmodifiableCollection( Arrays.asList( new Class[] {
+				AdvancedDoGDetectorMamut.class
+		} ) );
+		final Collection< Class< ? extends SpotDetectorOp > > a = b;
+		return a;
+	}
+
+	@Override
+	public void aboutToHidePanel()
+	{
+		if ( null != viewFrame )
+			viewFrame.dispose();
+		viewFrame = null;
+
+		grabSettings();
+		final Integer setupID = ( Integer ) settings.values.getDetectorSettings().get( DetectorKeys.KEY_SETUP_ID );
+		final String units = ( null != setupID && null != settings.values.getSpimData() )
+				? settings.values.getSpimData().getSequenceDescription()
+						.getViewSetups().get( setupID ).getVoxelSize().unit()
+				: "pixels";
+
+		final SpimDataMinimal spimData = settings.values.getSpimData();
+		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
+		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
+		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
+		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );
+		final AffineTransform3D transform = DetectionUtil.getTransform( spimData, timepoint, setupID, level );
+
+		final double sx = Affine3DHelpers.extractScale( mipmapTransform, 0 );
+		final double sy = Affine3DHelpers.extractScale( mipmapTransform, 1 );
+		final double sz = Affine3DHelpers.extractScale( mipmapTransform, 2 );
+
+		final double px = Affine3DHelpers.extractScale( transform, 0 );
+		final double py = Affine3DHelpers.extractScale( transform, 1 );
+		final double pz = Affine3DHelpers.extractScale( transform, 2 );
+
+		final double rx = radius / px;
+		final double ry = radius / py;
+		final double rz = radius / pz;
+
+		log.info( "Configured detector with parameters:\n" );
+		log.info( String.format( "  - spot radius: %.1f %s\n", radius, units ) );
+		log.info( String.format( "  - quality threshold: %.1f\n", ( double ) settings.values.getDetectorSettings().get( KEY_THRESHOLD ) ) );
+		final SequenceDescriptionMinimal seq = spimData.getSequenceDescription();
+		if ( seq.getImgLoader() instanceof BasicMultiResolutionImgLoader )
+		{
+			log.info( String.format( "  - will operate on resolution level %d (%.0f x %.0f x %.0f)\n", level, sx, sy, sz ) );
+			log.info( String.format( "  - at this level, radius = %.1f %s corresponds to:\n", radius, units ) );
+		}
+		else
+		{
+			log.info( String.format( "  - equivalent radius = %.1f %s in pixels:\n", radius, units ) );
+		}
+		log.info( String.format( "      - %.1f pixels in X.\n", rx ) );
+		log.info( String.format( "      - %.1f pixels in Y.\n", ry ) );
+		log.info( String.format( "      - %.1f pixels in Z.\n", rz ) );
+
+	}
+
+	private void preview()
+	{
+		if ( null == windowManager )
+			return;
+
+		final SharedBigDataViewerData shared = windowManager.getAppModel().getSharedBdvData();
+		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );
+		final int currentTimepoint = viewFrame.getViewerPanel().getState().getCurrentTimepoint();
+
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		panel.preview.setEnabled( false );
+		new Thread( "DogDetectorPanel preview thread" )
+		{
+			@Override
+			public void run()
+			{
+				try
+				{
+					grabSettings();
+					final boolean ok = WizardUtils.executeDetectionPreview( localModel, settings, ops, currentTimepoint );
+					if ( !ok )
+						return;
+
+					final int nSpots = WizardUtils.countSpotsIn( localModel, currentTimepoint );
+					panel.lblInfo.setText( "Found " + nSpots + " spots in time-point " + currentTimepoint );
+					plotQualityHistogram();
+				}
+				finally
+				{
+					panel.preview.setEnabled( true );
+				}
+			};
+		}.start();
+
+	}
+
+	private void plotQualityHistogram()
+	{
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+		if ( null != chartPanel )
+		{
+			panel.remove( chartPanel );
+			panel.repaint();
+		}
+		this.chartPanel = WizardUtils.createQualityHistogram( localModel );
+		if ( null == chartPanel )
+			return;
+
+		final GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridy = 7;
+		gbc.gridx = 0;
+		gbc.gridwidth = 3;
+		gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+		gbc.fill = GridBagConstraints.BOTH;
+		gbc.insets = new Insets( 5, 5, 5, 5 );
+		panel.add( chartPanel, gbc );
+		panel.revalidate();
+	}
+
+	@Override
+	public Map< String, Object > getDefaultSettings()
+	{
+		return DetectionUtil.getDefaultDetectorSettingsMap();
+	}
+
+	@Override
+	public void setTrackMate( final TrackMate trackmate )
+	{
+		final AdvancedDoGDetectorPanel panel = ( AdvancedDoGDetectorPanel ) targetPanel;
+
+		this.settings = trackmate.getSettings();
+		if ( null == settings )
+			return;
+
+		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+
+		final double diameter;
+		final Object objRadius = detectorSettings.get( KEY_RADIUS );
+		if ( null == objRadius )
+			diameter = 2. * DetectorKeys.DEFAULT_RADIUS;
+		else
+			diameter = 2. * ( double ) objRadius;
+
+		final double threshold;
+		final Object objThreshold = detectorSettings.get( KEY_THRESHOLD );
+		if ( null == objThreshold )
+			threshold = DetectorKeys.DEFAULT_THRESHOLD;
+		else
+			threshold = ( double ) objThreshold;
+
+
+		DetectionBehavior detectionBehavior = DetectionBehavior.ADD;
+		final String addBehavior = ( String ) detectorSettings.get( KEY_ADD_BEHAVIOR );
+		if ( null != addBehavior )
+		{
+			try
+			{
+				detectionBehavior = MamutDetectionCreatorFactories.DetectionBehavior.valueOf( addBehavior );
+			}
+			catch ( final IllegalArgumentException e )
+			{}
+		}
+		
+		final int setupID = ( int ) settings.values.getDetectorSettings().get( KEY_SETUP_ID );
+		final BasicViewSetup setup = settings.values.getSpimData().getSequenceDescription().getViewSetups().get( setupID );
+
+		panel.diameter.setValue( diameter );
+		panel.threshold.setValue( threshold );
+		panel.lblDiameterUnit.setText( setup.getVoxelSize().unit() );
+		panel.behaviorCB.setSelectedItem( detectionBehavior );
+	}
+
+	@Override
+	public void setWindowManager( final WindowManager windowManager )
+	{
+		this.windowManager = windowManager;
+	}
+
+	private class AdvancedDoGDetectorPanel extends JPanel
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final JFormattedTextField diameter;
+
+		private final JFormattedTextField threshold;
+
+		private final JLabel lblDiameterUnit;
+
+		private final JButton preview;
+
+		private final JLabel lblInfo;
+
+		private final JComboBox< DetectionBehavior > behaviorCB;
+
+		public AdvancedDoGDetectorPanel()
+		{
+			final GridBagLayout layout = new GridBagLayout();
+			layout.columnWidths = new int[] { 80, 80, 40 };
+			layout.columnWeights = new double[] { 0.2, 0.7, 0.1 };
+			layout.rowHeights = new int[] { 26, 0, 0, 0, 0, 50, 26, 26 };
+			layout.rowWeights = new double[] { 1., 0., 0., 0., 0., 0., 0., 1. };
+			setLayout( layout );
+
+			final GridBagConstraints gbc = new GridBagConstraints();
+			gbc.gridy = 0;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+			gbc.fill = GridBagConstraints.HORIZONTAL;
+			gbc.insets = new Insets( 5, 5, 5, 5 );
+
+			final JLabel title = new JLabel( "Configure detector." );
+			title.setFont( getFont().deriveFont( Font.BOLD ) );
+			add( title, gbc );
+
+			// Diameter.
+			final JLabel lblDiameter = new JLabel( "Estimated diameter:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridwidth = 1;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblDiameter, gbc );
+
+			this.diameter = new JFormattedTextField( FORMAT );
+			diameter.setHorizontalAlignment( JLabel.RIGHT );
+			diameter.addFocusListener( new SelectAllOnFocus( diameter ) );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( diameter, gbc );
+
+			lblDiameterUnit = new JLabel();
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.LINE_END;
+			add( lblDiameterUnit, gbc );
+
+			// Threshold.
+			final JLabel lblThreshold = new JLabel( "Quality threshold:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblThreshold, gbc );
+
+			this.threshold = new JFormattedTextField( FORMAT );
+			threshold.setHorizontalAlignment( JLabel.RIGHT );
+			threshold.addFocusListener( new SelectAllOnFocus( threshold ) );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( threshold, gbc );
+
+			// Behavior.
+			final JLabel lblAddBehavior = new JLabel( "Behavior:", JLabel.RIGHT );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+			add( lblAddBehavior, gbc );
+
+			this.behaviorCB = new JComboBox<>( MamutDetectionCreatorFactories.DetectionBehavior.values() );
+			gbc.gridx++;
+			gbc.anchor = GridBagConstraints.CENTER;
+			add( behaviorCB, gbc );
+
+			// Behavior info.
+			final JLabel lblAddBehaviorInfo = new JLabel( "<html>" + ( ( DetectionBehavior ) behaviorCB.getSelectedItem() ).info() + "</html>" );
+			gbc.gridy++;
+			gbc.fill = GridBagConstraints.HORIZONTAL;
+			gbc.anchor = GridBagConstraints.FIRST_LINE_START;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			add( lblAddBehaviorInfo, gbc );
+			
+			// Hook it to changes in the CB.
+			behaviorCB.addItemListener( ( e ) -> lblAddBehaviorInfo.setText( "<html>" + ( ( DetectionBehavior ) behaviorCB.getSelectedItem() ).info() + "</html>" ) );
+
+			// Preview button.
+			preview = new JButton( "Preview", PREVIEW_ICON );
+			preview.addActionListener( ( e ) -> preview() );
+			gbc.gridy++;
+			gbc.gridx = 0;
+			gbc.gridwidth = 3;
+			gbc.anchor = GridBagConstraints.EAST;
+			gbc.fill = GridBagConstraints.NONE;
+			add( preview, gbc );
+
+			// Info text.
+			this.lblInfo = new JLabel( "", JLabel.RIGHT );
+			lblInfo.setFont( getFont().deriveFont( getFont().getSize2D() - 2f ) );
+			gbc.gridwidth = 3;
+			gbc.gridy++;
+			gbc.gridx = 0;
+			add( lblInfo, gbc );
+
+			// Quality histogram place holder.
+		}
+	}
+
+	private static class SelectAllOnFocus extends FocusAdapter
+	{
+		private final JFormattedTextField textField;
+
+		public SelectAllOnFocus( final JFormattedTextField textField )
+		{
+			this.textField = textField;
+		}
+
+		@Override
+		public void focusGained( final FocusEvent e )
+		{
+			SwingUtilities.invokeLater( () -> textField.selectAll() );
+		}
+	}
+
+	public static void main( final String[] args )
+	{
+		final AdvancedDoGDetectorDescriptor desc = new AdvancedDoGDetectorDescriptor();
+
+		final JFrame frame = new JFrame( "Test" );
+		frame.getContentPane().add( desc.targetPanel );
+		frame.setSize( 300, 600 );
+		desc.aboutToDisplayPanel();
+		frame.setVisible( true );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
@@ -94,7 +94,7 @@ public class BoundingBoxDescriptor extends WizardPanelDescriptor implements Cont
 		this.targetPanel = new BoundingBoxPanel();
 	}
 
-	private int previousSetupID = -1;
+	private static int previousSetupID = -1;
 
 	@Override
 	public void aboutToDisplayPanel()
@@ -111,60 +111,62 @@ public class BoundingBoxDescriptor extends WizardPanelDescriptor implements Cont
 		final int setupID = ( int ) settings.values.getDetectorSettings().get( KEY_SETUP_ID );
 		if ( setupID != previousSetupID )
 		{
-			// Remove old overlay.
-			if ( boundingBoxEditor != null )
-				boundingBoxEditor.uninstall();
-			viewFrame = null;
-
-			/*
-			 * Change ROI source and overlay.
-			 */
-			roi = getBoundingBoxModel();
-			roi.intervalChangedListeners().add( () -> {
-				panel.boxSelectionPanel.updateSliders( roi.getInterval() );
-				if ( viewFrame != null )
-					viewFrame.getViewerPanel().getDisplay().repaint();
-			} );
-
-			/*
-			 * We also have to recreate the selection panel linked to the new
-			 * ROI.
-			 */
-			panel.boxSelectionPanel = new BoxSelectionPanel( roi, roi.getMaxInterval() );
-
-			/*
-			 * We reset time bounds.
-			 */
-
-			final int nTimepoints = wm.getAppModel().getMaxTimepoint() - wm.getAppModel().getMinTimepoint();
-
-			panel.minT = new BoundedValue( 0, nTimepoints, 0 );
-			final SliderPanel tMinPanel = new SliderPanel( "t min", panel.minT, 1 );
-			tMinPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
-
-			panel.maxT = new BoundedValue( 0, nTimepoints, nTimepoints );
-			final SliderPanel tMaxPanel = new SliderPanel( "t max", panel.maxT, 1 );
-			tMaxPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
-
-			panel.boundsPanel.removeAll();
-			panel.boundsPanel.add( panel.boxSelectionPanel );
-			panel.boundsPanel.add( tMinPanel );
-			panel.boundsPanel.add( tMaxPanel );
-
-			setPanelEnabled( panel.boundsPanel, panel.useRoi.isSelected() );
-			setPanelEnabled( panel.boxModePanel, panel.useRoi.isSelected() );
-
-			panel.boxSelectionPanel.setBoundsInterval( roi.getMaxInterval() );
-			panel.boxSelectionPanel.updateSliders( roi.getInterval() );
-
-			previousSetupID = setupID;
+			settings.values.getDetectorSettings().put( KEY_ROI, null );
+			panel.useRoi.setSelected( false );
 		}
 		else
 		{
-			panel.minT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT ) );
-			panel.maxT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MAX_TIMEPOINT ) );
+			panel.useRoi.setSelected( null != settings.values.getDetectorSettings().get( KEY_ROI ) );
 		}
 
+		// Remove old overlay.
+		if ( boundingBoxEditor != null )
+			boundingBoxEditor.uninstall();
+		viewFrame = null;
+
+		/*
+		 * We force a reset of the ROI source and overlay.
+		 */
+		roi = getBoundingBoxModel();
+		roi.intervalChangedListeners().add( () -> {
+			panel.boxSelectionPanel.updateSliders( roi.getInterval() );
+			if ( viewFrame != null )
+				viewFrame.getViewerPanel().getDisplay().repaint();
+		} );
+
+		/*
+		 * We also have to recreate the selection panel linked to the new ROI.
+		 */
+		panel.boxSelectionPanel = new BoxSelectionPanel( roi, roi.getMaxInterval() );
+
+		/*
+		 * We reset time bounds.
+		 */
+
+		final int nTimepoints = wm.getAppModel().getMaxTimepoint() - wm.getAppModel().getMinTimepoint();
+
+		panel.minT = new BoundedValue( 0, nTimepoints, 0 );
+		final SliderPanel tMinPanel = new SliderPanel( "t min", panel.minT, 1 );
+		tMinPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
+
+		panel.maxT = new BoundedValue( 0, nTimepoints, nTimepoints );
+		final SliderPanel tMaxPanel = new SliderPanel( "t max", panel.maxT, 1 );
+		tMaxPanel.setBorder( BorderFactory.createEmptyBorder( 0, 10, 10, 10 ) );
+
+		panel.boundsPanel.removeAll();
+		panel.boundsPanel.add( panel.boxSelectionPanel );
+		panel.boundsPanel.add( tMinPanel );
+		panel.boundsPanel.add( tMaxPanel );
+
+		setPanelEnabled( panel.boundsPanel, panel.useRoi.isSelected() );
+		setPanelEnabled( panel.boxModePanel, panel.useRoi.isSelected() );
+
+		panel.boxSelectionPanel.setBoundsInterval( roi.getMaxInterval() );
+		panel.boxSelectionPanel.updateSliders( roi.getInterval() );
+
+		previousSetupID = setupID;
+		panel.minT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT ) );
+		panel.maxT.setCurrentValue( ( int ) settings.values.getDetectorSettings().get( KEY_MAX_TIMEPOINT ) );
 		toggleBoundingBoxVisibility( panel.useRoi.isSelected() );
 	}
 

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -30,7 +30,7 @@ import javax.swing.SwingUtilities;
 import org.jfree.chart.ChartPanel;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
 import org.mastodon.detection.mamut.LoGDetectorMamut;
 import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
@@ -84,7 +84,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 	public DoGDetectorDescriptor()
 	{
 		this.panelIdentifier = IDENTIFIER;
-		this.targetPanel = new DogDetectorPanel();
+		this.targetPanel = new DoGDetectorPanel();
 		/*
 		 * Use a separate model for the preview. We do not want to touch the
 		 * existing model.
@@ -108,7 +108,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		final SpimDataMinimal spimData = settings.values.getSpimData();
 		final double radius = ( double ) settings.values.getDetectorSettings().get( KEY_RADIUS );
-		final double minSizePixel = DogDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
+		final double minSizePixel = DoGDetectorOp.MIN_SPOT_PIXEL_SIZE / 2.;
 		final int timepoint = ( int ) settings.values.getDetectorSettings().get( KEY_MIN_TIMEPOINT );
 		final int level = DetectionUtil.determineOptimalResolutionLevel( spimData, radius, minSizePixel, timepoint, setupID );
 		final AffineTransform3D mipmapTransform = DetectionUtil.getMipmapTransform( spimData, timepoint, setupID, level );
@@ -154,7 +154,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );
 		final int currentTimepoint = viewFrame.getViewerPanel().getState().getCurrentTimepoint();
 
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		panel.preview.setEnabled( false );
 		new Thread( "DogDetectorPanel preview thread" )
 		{
@@ -183,7 +183,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 	private void plotQualityHistogram()
 	{
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		if ( null != chartPanel )
 		{
 			panel.remove( chartPanel );
@@ -213,7 +213,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		if ( null == settings )
 			return;
 
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
 		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
 		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
@@ -241,7 +241,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void setTrackMate( final TrackMate trackmate )
 	{
-		final DogDetectorPanel panel = ( DogDetectorPanel ) targetPanel;
+		final DoGDetectorPanel panel = ( DoGDetectorPanel ) targetPanel;
 
 		this.settings = trackmate.getSettings();
 		if ( null == settings )
@@ -277,7 +277,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		this.windowManager = windowManager;
 	}
 
-	private class DogDetectorPanel extends JPanel
+	private class DoGDetectorPanel extends JPanel
 	{
 
 		private static final long serialVersionUID = 1L;
@@ -292,7 +292,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 
 		private final JLabel lblInfo;
 
-		public DogDetectorPanel()
+		public DoGDetectorPanel()
 		{
 			final GridBagLayout layout = new GridBagLayout();
 			layout.columnWidths = new int[] { 80, 80, 40 };

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate.ui.wizard.descriptors;
 
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
@@ -32,6 +33,7 @@ import org.mastodon.detection.DetectorKeys;
 import org.mastodon.detection.DogDetectorOp;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
 import org.mastodon.detection.mamut.LoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories;
 import org.mastodon.detection.mamut.SpotDetectorOp;
 import org.mastodon.revised.bdv.SharedBigDataViewerData;
 import org.mastodon.revised.bdv.ViewerFrameMamut;
@@ -215,6 +217,7 @@ public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
 		detectorSettings.put( KEY_RADIUS, ( ( Number ) panel.diameter.getValue() ).doubleValue() / 2. );
 		detectorSettings.put( KEY_THRESHOLD, ( ( Number ) panel.threshold.getValue() ).doubleValue() );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, MamutDetectionCreatorFactories.DetectionBehavior.REMOVEALL.name() );
 	}
 
 	@SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DoGDetectorDescriptor.java
@@ -54,7 +54,7 @@ import net.imagej.ops.OpService;
 import net.imglib2.realtransform.AffineTransform3D;
 
 @Plugin( type = SpotDetectorDescriptor.class, name = "DoG detector configuration descriptor" )
-public class DogDetectorDescriptor extends SpotDetectorDescriptor
+public class DoGDetectorDescriptor extends SpotDetectorDescriptor
 {
 
 	public static final String IDENTIFIER = "Configure DoG detector";
@@ -79,7 +79,7 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 
 	private final Model localModel;
 
-	public DogDetectorDescriptor()
+	public DoGDetectorDescriptor()
 	{
 		this.panelIdentifier = IDENTIFIER;
 		this.targetPanel = new DogDetectorPanel();
@@ -93,7 +93,8 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void aboutToHidePanel()
 	{
-		viewFrame.dispose();
+		if ( null != viewFrame )
+			viewFrame.dispose();
 		viewFrame = null;
 
 		grabSettings();
@@ -187,6 +188,8 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 			panel.repaint();
 		}
 		this.chartPanel = WizardUtils.createQualityHistogram( localModel );
+		if ( null == chartPanel )
+			return;
 
 		final GridBagConstraints gbc = new GridBagConstraints();
 		gbc.gridy = 5;

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
@@ -40,7 +40,7 @@ import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.trackmate.Settings;
 import org.mastodon.trackmate.TrackMate;
 import org.mastodon.trackmate.ui.wizard.Wizard;
-import org.mastodon.trackmate.ui.wizard.WizardUtils;
+import org.mastodon.trackmate.ui.wizard.util.WizardUtils;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -144,7 +144,6 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	{
 		if ( null == windowManager )
 			return;
-
 
 		final SharedBigDataViewerData shared = windowManager.getAppModel().getSharedBdvData();
 		viewFrame = WizardUtils.previewFrame( viewFrame, shared, localModel );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/DogDetectorDescriptor.java
@@ -93,8 +93,10 @@ public class DogDetectorDescriptor extends SpotDetectorDescriptor
 	@Override
 	public void aboutToHidePanel()
 	{
-		grabSettings();
+		viewFrame.dispose();
+		viewFrame = null;
 
+		grabSettings();
 		final Integer setupID = ( Integer ) settings.values.getDetectorSettings().get( DetectorKeys.KEY_SETUP_ID );
 		final String units = ( null != setupID && null != settings.values.getSpimData() )
 				? settings.values.getSpimData().getSequenceDescription()

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/LinkingTargetDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/LinkingTargetDescriptor.java
@@ -1,0 +1,240 @@
+package org.mastodon.trackmate.ui.wizard.descriptors;
+
+import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
+import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
+import static org.mastodon.linking.LinkerKeys.KEY_DO_LINK_SELECTION;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.model.SelectionListener;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.revised.mamut.MainWindow;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.MamutProjectIO;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Spot;
+import org.mastodon.trackmate.Settings;
+import org.mastodon.trackmate.TrackMate;
+import org.mastodon.trackmate.ui.wizard.WizardPanelDescriptor;
+import org.scijava.Context;
+
+import bdv.tools.brightness.SliderPanel;
+import bdv.util.BoundedValue;
+import mpicbg.spim.data.SpimDataException;
+
+public class LinkingTargetDescriptor extends WizardPanelDescriptor
+{
+
+	private final TrackMate trackmate;
+
+	private final SelectionModel< Spot, Link > selectionModel;
+
+	public LinkingTargetDescriptor( final TrackMate trackmate, final WindowManager windowManager )
+	{
+		this.trackmate = trackmate;
+		this.selectionModel = windowManager.getAppModel().getSelectionModel();
+		final int nTimepoints = windowManager.getAppModel().getMaxTimepoint() - windowManager.getAppModel().getMinTimepoint();
+		this.targetPanel = new LinkingTargetPanel( nTimepoints );
+	}
+
+	@Override
+	public void aboutToDisplayPanel()
+	{
+		final LinkingTargetPanel panel = ( ( LinkingTargetPanel ) targetPanel );
+		selectionModel.listeners().add( panel );
+
+		final Settings settings = trackmate.getSettings();
+		final Map< String, Object > linkerSettings = settings.values.getLinkerSettings();
+		final boolean doLinkSelection = ( boolean ) linkerSettings.get( KEY_DO_LINK_SELECTION );
+		final int minT = ( int ) linkerSettings.get( KEY_MIN_TIMEPOINT );
+		final int maxT = ( int ) linkerSettings.get( KEY_MAX_TIMEPOINT );
+
+		panel.btnAllSpots.setSelected( !doLinkSelection );
+		panel.minT.setCurrentValue( minT );
+		panel.maxT.setCurrentValue( maxT );
+	}
+
+	@Override
+	public void aboutToHidePanel()
+	{
+		final LinkingTargetPanel panel = ( ( LinkingTargetPanel ) targetPanel );
+		selectionModel.listeners().remove( panel );
+
+		final Settings settings = trackmate.getSettings();
+		final Map< String, Object > linkerSettings = settings.values.getLinkerSettings();
+		linkerSettings.put( KEY_DO_LINK_SELECTION, !panel.btnAllSpots.isSelected() );
+		linkerSettings.put( KEY_MIN_TIMEPOINT, panel.minT.getCurrentValue() );
+		linkerSettings.put( KEY_MAX_TIMEPOINT, panel.maxT.getCurrentValue() );
+	}
+
+	private class LinkingTargetPanel extends JPanel implements SelectionListener
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final BoundedValue minT;
+
+		private final BoundedValue maxT;
+
+		private final JRadioButton btnAllSpots;
+
+		private final JLabel lblInfo;
+
+		public LinkingTargetPanel( final int nTimepoints )
+		{
+			final GridBagLayout layout = new GridBagLayout();
+			layout.columnWidths = new int[] { 80, 80 };
+			layout.columnWeights = new double[] { 0.5, 0.5 };
+			layout.rowHeights = new int[] { 0, 0, 0, 0, 0, 30 };
+			layout.rowWeights = new double[] { 0., 1., 0., 0., 0., 0., 1.0 };
+			setLayout( layout );
+
+			final GridBagConstraints gbc = new GridBagConstraints();
+			gbc.gridy = 0;
+			gbc.gridx = 0;
+			gbc.gridwidth = 2;
+			gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+			gbc.fill = GridBagConstraints.HORIZONTAL;
+			gbc.insets = new Insets( 5, 5, 5, 5 );
+
+			final JLabel title = new JLabel( "Linker target." );
+			title.setFont( getFont().deriveFont( Font.BOLD ) );
+			add( title, gbc );
+
+			final JLabel lblPick = new JLabel( "Perform linking on:" );
+			gbc.gridy = 1;
+			gbc.anchor = GridBagConstraints.SOUTHWEST;
+			add( lblPick, gbc );
+
+			gbc.gridy = 2;
+			this.btnAllSpots = new JRadioButton( "All spots, between time-points:" );
+			add( btnAllSpots, gbc );
+
+			gbc.gridy = 3;
+			this.minT = new BoundedValue( 0, nTimepoints, 0 );
+			final SliderPanel tMinPanel = new SliderPanel( "t min", minT, 1 );
+			add( tMinPanel, gbc );
+
+			gbc.gridy = 4;
+			this.maxT = new BoundedValue( 0, nTimepoints, nTimepoints );
+			final SliderPanel tMaxPanel = new SliderPanel( "t max", maxT, 1 );
+			add( tMaxPanel, gbc );
+
+			gbc.gridy = 5;
+			final JRadioButton btnSelection = new JRadioButton( "Spots in selection." );
+			add( btnSelection, gbc );
+
+			gbc.gridy = 6;
+			gbc.anchor = GridBagConstraints.NORTHWEST;
+			lblInfo = new JLabel( " " );
+			lblInfo.setFont( getFont().deriveFont( getFont().getSize2D() - 2f ) );
+			lblInfo.setVerticalAlignment( JLabel.TOP );
+			add( lblInfo, gbc );
+
+			final ButtonGroup buttonGroup = new ButtonGroup();
+			buttonGroup.add( btnAllSpots );
+			buttonGroup.add( btnSelection );
+
+			btnAllSpots.addItemListener( ( e ) -> {
+				LinkingTargetDescriptor.setEnabled( tMinPanel, btnAllSpots.isSelected() );
+				LinkingTargetDescriptor.setEnabled( tMaxPanel, btnAllSpots.isSelected() );
+				selectionChanged();
+			} );
+		}
+
+		@Override
+		public void selectionChanged()
+		{
+			if ( btnAllSpots.isSelected() )
+			{
+				lblInfo.setText( " " );
+			}
+			else
+			{
+				new Thread( "Investigate selection thread" )
+				{
+					@Override
+					public void run()
+					{
+						final int nSpots = selectionModel.getSelectedVertices().size();
+						if ( nSpots == 0 )
+						{
+							SwingUtilities.invokeLater( () -> lblInfo.setText( "Selection is empty." ) );
+							return;
+						}
+						int tmin = Integer.MAX_VALUE;
+						int tmax = Integer.MIN_VALUE;
+						for ( final Spot spot : selectionModel.getSelectedVertices() )
+						{
+							if ( spot.getTimepoint() > tmax )
+								tmax = spot.getTimepoint();
+							if ( spot.getTimepoint() < tmin )
+								tmin = spot.getTimepoint();
+						}
+						final int tmin2 = tmin;
+						final int tmax2 = tmax;
+						SwingUtilities.invokeLater( () -> lblInfo.setText( "Selection has " + nSpots
+								+ " spots, from t = " + tmin2 + " to t = " + tmax2 + "." ) );
+					}
+				}.start();
+			}
+		}
+	}
+
+	private static void setEnabled( final Component component, final boolean enabled )
+	{
+		component.setEnabled( enabled );
+		if ( component instanceof Container )
+		{
+			for ( final Component child : ( ( Container ) component ).getComponents() )
+			{
+				setEnabled( child, enabled );
+			}
+		}
+	}
+
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		final Context context = new Context();
+		final String projectFile = "../TrackMate3/samples/mamutproject";
+
+		final WindowManager windowManager = new WindowManager( context );
+		final MainWindow mw = new MainWindow( windowManager );
+
+		final MamutProject project = new MamutProjectIO().load( projectFile );
+		windowManager.getProjectManager().open( project );
+
+		mw.setVisible( true );
+
+		final Settings settings = new Settings();
+		final TrackMate trackmate = new TrackMate( settings, windowManager.getAppModel().getModel() );
+		final LinkingTargetDescriptor desc = new LinkingTargetDescriptor( trackmate, windowManager );
+
+		final JFrame frame = new JFrame( "Test" );
+		frame.getContentPane().add( desc.targetPanel );
+		frame.setSize( 300, 600 );
+		desc.aboutToDisplayPanel();
+		frame.setVisible( true );
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SetupIdDecriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SetupIdDecriptor.java
@@ -1,5 +1,7 @@
 package org.mastodon.trackmate.ui.wizard.descriptors;
 
+import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
+import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_SETUP_ID;
 
 import java.awt.Font;
@@ -105,9 +107,13 @@ public class SetupIdDecriptor extends WizardPanelDescriptor implements ActionLis
 	{
 		final SetupIdConfigPanel panel = ( SetupIdConfigPanel ) targetPanel;
 		final Object obj = panel.comboBox.getSelectedItem();
-		final Integer setupID = idMap.get( obj );
 		final Map< String, Object > detectorSettings = settings.values.getDetectorSettings();
+		final Integer setupID = idMap.get( obj );
 		detectorSettings.put( KEY_SETUP_ID, setupID );
+		final SpimDataMinimal spimData = settings.values.getSpimData();
+		final int nTimePoints = spimData.getSequenceDescription().getTimePoints().getTimePoints().size();
+		detectorSettings.put( KEY_MIN_TIMEPOINT, Integer.valueOf( 0 ) );
+		detectorSettings.put( KEY_MAX_TIMEPOINT, Integer.valueOf( nTimePoints - 1 ) );
 
 		log.log( String.format( "Selected setup ID %d for detection:\n", ( int ) setupID ) );
 		log.log( echoSetupIDInfo( setupID ) );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SimpleLAPLinkerDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/SimpleLAPLinkerDescriptor.java
@@ -241,23 +241,23 @@ public class SimpleLAPLinkerDescriptor extends SpotLinkerDescriptor
 			// Panel settings.
 			// Frame to frame linking
 			ls.put( KEY_LINKING_MAX_DISTANCE, ( ( Number ) maxLinkingDistance.getValue() ).doubleValue() );
-			ls.put( KEY_LINKING_FEATURE_PENALTIES, null );
+			ls.put( KEY_LINKING_FEATURE_PENALTIES, new HashMap<>() );
 
 			// Gap-closing.
 			ls.put( KEY_ALLOW_GAP_CLOSING, true );
 			ls.put( KEY_GAP_CLOSING_MAX_DISTANCE, ( ( Number ) maxGapClosingDistance.getValue() ).doubleValue() );
 			ls.put( KEY_GAP_CLOSING_MAX_FRAME_GAP, ( ( Number ) maxFrameGap.getValue() ).intValue() );
-			ls.put( KEY_GAP_CLOSING_FEATURE_PENALTIES, null );
+			ls.put( KEY_GAP_CLOSING_FEATURE_PENALTIES, new HashMap<>() );
 
 			// Track splitting.
 			ls.put( KEY_ALLOW_TRACK_SPLITTING, false );
 			ls.put( KEY_SPLITTING_MAX_DISTANCE, DEFAULT_SPLITTING_MAX_DISTANCE );
-			ls.put( KEY_SPLITTING_FEATURE_PENALTIES, null );
+			ls.put( KEY_SPLITTING_FEATURE_PENALTIES, new HashMap<>() );
 
 			// Track merging.
 			ls.put( KEY_ALLOW_TRACK_MERGING, false );
 			ls.put( KEY_MERGING_MAX_DISTANCE, DEFAULT_MERGING_MAX_DISTANCE );
-			ls.put( KEY_MERGING_FEATURE_PENALTIES, null );
+			ls.put( KEY_MERGING_FEATURE_PENALTIES, new HashMap<>() );
 
 			// Other - use defaults.
 			ls.put( KEY_BLOCKING_VALUE, DEFAULT_BLOCKING_VALUE );

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/SetupIDComboBox.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/SetupIDComboBox.java
@@ -1,0 +1,165 @@
+package org.mastodon.trackmate.ui.wizard.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.util.Affine3DHelpers;
+import mpicbg.spim.data.generic.base.Entity;
+import mpicbg.spim.data.generic.base.NamedEntity;
+import mpicbg.spim.data.generic.sequence.BasicMultiResolutionImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicMultiResolutionSetupImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Dimensions;
+import net.imglib2.realtransform.AffineTransform3D;
+
+/**
+ * A combo-box that lets the user select one of the setup ids present in a spim
+ * data.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class SetupIDComboBox extends JComboBox< String >
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private final Map< String, Integer > idMap;
+
+	private final Map< Integer, String > strMap;
+
+	private final SpimDataMinimal spimData;
+
+	public SetupIDComboBox( final SpimDataMinimal spimData )
+	{
+		this.spimData = spimData;
+		if ( null == spimData )
+		{
+			this.idMap = new HashMap<>( 1 );
+			this.strMap = new HashMap<>( 1 );
+			final String str = "No spim data";
+			final Integer id = Integer.valueOf( -1 );
+			idMap.put( str, id );
+			strMap.put( id, str );
+			final ComboBoxModel< String > aModel = new DefaultComboBoxModel<>( new String[] { str } );
+			setModel( aModel );
+		}
+		else
+		{
+			final List< BasicViewSetup > setups = spimData.getSequenceDescription().getViewSetupsOrdered();
+			final int nSetups = setups.size();
+			this.idMap = new HashMap<>( nSetups );
+			this.strMap = new HashMap<>( nSetups );
+
+			final String[] items = new String[ nSetups ];
+			int i = 0;
+			for ( final BasicViewSetup setup : setups )
+			{
+				final int setupID = setup.getId();
+				final String name = setup.getName();
+				final Dimensions size = setup.getSize();
+
+				final String str = ( null == name )
+						? setupID + "  -  " + size.dimension( 0 ) + " x " + size.dimension( 1 ) + " x " + size.dimension( 2 )
+						: setupID + "  -  " + name;
+				items[ i++ ] = str;
+				idMap.put( str, setupID );
+				strMap.put( setupID, str );
+			}
+
+			final ComboBoxModel< String > aModel = new DefaultComboBoxModel<>( items );
+			setModel( aModel );
+		}
+	}
+
+	/**
+	 * Returns the id of the setup id currently selected.
+	 * 
+	 * @return the setup id.
+	 */
+	public int getSelectedSetupID()
+	{
+		return idMap.get( getSelectedItem() );
+	}
+
+	/**
+	 * Sets the specified setup id as selection.
+	 * 
+	 * @param setupID
+	 *            the setup id to select.
+	 */
+	public void setSelectedSetupID( final int setupID )
+	{
+		setSelectedItem( strMap.get( Integer.valueOf( setupID ) ) );
+	}
+
+	/**
+	 * Returns an explanatory string that states what resolutions are available
+	 * in the {@link SpimDataMinimal} for the currently selected setup id.
+	 * 
+	 * @return a string.
+	 */
+	public String echoSetupIDInfo()
+	{
+		if ( spimData == null )
+			return "No spim data.";
+		final BasicViewSetup setup = spimData.getSequenceDescription().getViewSetups().get( getSelectedSetupID() );
+
+		final StringBuilder str = new StringBuilder();
+		final Dimensions size = setup.getSize();
+		str.append( "  - size: " + size.dimension( 0 ) + " x " + size.dimension( 1 ) + " x " + size.dimension( 2 ) + "\n" );
+
+		final VoxelDimensions voxelSize = setup.getVoxelSize();
+		str.append( "  - voxel size: " + voxelSize.dimension( 0 ) + " x " + voxelSize.dimension( 1 ) + " x "
+				+ voxelSize.dimension( 2 ) + " " + voxelSize.unit() + "\n" );
+
+		final Map< String, Entity > attributes = setup.getAttributes();
+		for ( final String key : attributes.keySet() )
+		{
+			final Entity entity = attributes.get( key );
+			if ( entity instanceof NamedEntity )
+			{
+				final NamedEntity ne = ( NamedEntity ) entity;
+				str.append( "  - " + key + ": " + ne.getName() + "\n" );
+			}
+		}
+
+		if ( spimData.getSequenceDescription().getImgLoader() instanceof BasicMultiResolutionImgLoader )
+		{
+			final BasicMultiResolutionSetupImgLoader< ? > loader =
+					( ( BasicMultiResolutionImgLoader ) spimData.getSequenceDescription().getImgLoader() )
+							.getSetupImgLoader( getSelectedSetupID() );
+
+			final int numMipmapLevels = loader.numMipmapLevels();
+
+			if ( numMipmapLevels > 1 )
+			{
+				final AffineTransform3D[] mipmapTransforms = loader.getMipmapTransforms();
+				str.append( String.format( "  - multi-resolution image with %d levels:\n", numMipmapLevels ) );
+				for ( int level = 0; level < mipmapTransforms.length; level++ )
+				{
+					final double sx = Affine3DHelpers.extractScale( mipmapTransforms[ level ], 0 );
+					final double sy = Affine3DHelpers.extractScale( mipmapTransforms[ level ], 1 );
+					final double sz = Affine3DHelpers.extractScale( mipmapTransforms[ level ], 2 );
+					str.append( String.format( "     - level %d: %.0f x %.0f x %.0f\n", level, sx, sy, sz ) );
+				}
+			}
+			else
+			{
+				str.append( " - single-resolution image.\n" );
+			}
+		}
+		else
+		{
+			str.append( " - single-resolution image.\n" );
+		}
+
+		return str.toString();
+	}
+}

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
@@ -1,5 +1,6 @@
 package org.mastodon.trackmate.ui.wizard.util;
 
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
 
@@ -25,6 +26,7 @@ import org.mastodon.collection.RefList;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorKeys;
 import org.mastodon.detection.mamut.DoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
 import org.mastodon.graph.GraphIdBimap;
 import org.mastodon.grouping.GroupManager;
 import org.mastodon.model.DefaultFocusModel;
@@ -183,6 +185,7 @@ public class WizardUtils
 		final Map< String, Object > detectorSettings = localSettings.values.getDetectorSettings();
 		detectorSettings.put( KEY_MIN_TIMEPOINT, currentTimepoint );
 		detectorSettings.put( KEY_MAX_TIMEPOINT, currentTimepoint );
+		detectorSettings.put( KEY_ADD_BEHAVIOR, DetectionBehavior.REMOVEALL.name() );
 
 		/*
 		 * Execute preview.

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
@@ -1,4 +1,4 @@
-package org.mastodon.trackmate.ui.wizard;
+package org.mastodon.trackmate.ui.wizard.util;
 
 import static org.mastodon.detection.DetectorKeys.KEY_MAX_TIMEPOINT;
 import static org.mastodon.detection.DetectorKeys.KEY_MIN_TIMEPOINT;
@@ -56,7 +56,6 @@ import org.mastodon.revised.ui.keymap.Keymap;
 import org.mastodon.revised.ui.keymap.KeymapManager;
 import org.mastodon.spatial.SpatialIndex;
 import org.mastodon.trackmate.Settings;
-import org.mastodon.trackmate.ui.wizard.util.HistogramUtil;
 import org.scijava.Context;
 import org.scijava.log.LogService;
 import org.scijava.ui.behaviour.util.Actions;

--- a/src/main/java/org/mastodon/util/EllipsoidInsideTest.java
+++ b/src/main/java/org/mastodon/util/EllipsoidInsideTest.java
@@ -1,0 +1,94 @@
+package org.mastodon.util;
+
+import org.mastodon.revised.model.mamut.Spot;
+
+import net.imglib2.util.LinAlgHelpers;
+
+/**
+ * Offers facilities to determine whether a point is inside an ellipsoid, as
+ * specified by a <code>double[3][3]</code> covariance matrix like in Mastodon.
+ * <p>
+ * Adapted from ScreenVertexMath.
+ */
+public class EllipsoidInsideTest
+{
+
+	/** Holder for the first spot position. */
+	private final double[] pos1 = new double[ 3 ];
+
+	/** Holder for the second spot position. */
+	private final double[] pos2 = new double[ 3 ];
+
+	/** Holder for the covariance position. */
+	private final double[][] cov = new double[ 3 ][ 3 ];
+
+	/** Used to determines whether a spot contains a position. */
+	private final double[] diff = new double[ 3 ];
+
+	/** Used to determines whether a spot contains a position. */
+	private final double[] vn = new double[ 3 ];
+
+	/** Precision. */
+	private final double[][] P = new double[ 3 ][ 3 ];
+
+	/**
+	 * Returns <code>true</code> if the first spot contains the center of the
+	 * second one, or if the second spot contains the center of the first one.
+	 *
+	 * @param s1
+	 *            the first spot.
+	 * @param s2
+	 *            the second spot.
+	 * @return <code>true</code> if a center of spot is included in the other
+	 *         spot.
+	 */
+	public boolean areCentersInside( final Spot s1, final Spot s2 )
+	{
+		s2.localize( pos2 );
+		if ( isPointInside( pos2, s1 ) )
+			return true;
+
+		s1.localize( pos2 );
+		return isPointInside( pos2, s2 );
+	}
+
+	/**
+	 * Returns <code>true</code> is the specified position lies inside the spot
+	 * ellipsoid.
+	 *
+	 * @param pos
+	 *            the position to test.
+	 * @param spot
+	 *            the spot.
+	 * @return <code>true</code> if the position is inside the spot.
+	 */
+	public boolean isPointInside( final double[] pos, final Spot spot )
+	{
+		spot.localize( pos1 );
+		LinAlgHelpers.subtract( pos1, pos, diff );
+		spot.getCovariance( cov );
+		LinAlgHelpers.invertSymmetric3x3( cov, P );
+		LinAlgHelpers.mult( P, diff, vn );
+		final double d2 = LinAlgHelpers.dot( diff, vn );
+		return d2 < 1.;
+	}
+
+	/**
+	 * Returns <code>true</code> if the spot center is within the specified
+	 * radius around the specified position.
+	 *
+	 * @param spot
+	 *            the spot to test.
+	 * @param pos
+	 *            the position.
+	 * @param radius
+	 *            the radius.
+	 * @return <code>true</code> if the spot center is within
+	 *         <code>radius</code> of <code>pos</code>.
+	 */
+	public boolean isCenterWithin( final Spot spot, final double[] pos, final double radius )
+	{
+		spot.localize( pos1 );
+		return LinAlgHelpers.squareDistance( pos1, pos ) < radius * radius;
+	}
+}

--- a/src/test/java/org/mastodon/trackmate/TestDrive.java
+++ b/src/test/java/org/mastodon/trackmate/TestDrive.java
@@ -1,0 +1,43 @@
+package org.mastodon.trackmate;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.revised.mamut.MainWindow;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.scijava.Context;
+
+import mpicbg.spim.data.SpimDataException;
+
+public class TestDrive
+{
+
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		final Context context = new Context();
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+//		final String bdvFile = "/Users/Jean-Yves/Desktop/MaMuT_demo_dataset/MaMuT_Parhyale_demo.xml";
+//		final String bdvFile = "/Users/pietzsch/Desktop/data/MAMUT/MaMuT_demo_dataset/MaMuT_Parhyale_demo.xml";
+//		final String bdvFile = "/Users/tinevez/Projects/JYTinevez/MaMuT/MaMuT_demo_dataset/MaMuT_Parhyale_demo.xml";
+//		final String bdvFile = "/Users/tinevez/Projects/JYTinevez/MaMuT/MaMuT_demo_dataset/MaMuT_Parhyale_demo.xml";
+//		final String projectFile = "../TrackMate3/samples/mamutproject";
+
+		final WindowManager windowManager = new WindowManager( context );
+		final MainWindow mw = new MainWindow( windowManager );
+
+//		final MamutProject project = new MamutProjectIO().load( projectFile );
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+		windowManager.getProjectManager().open( project );
+
+		mw.setVisible( true );
+	}
+}

--- a/src/test/java/org/mastodon/trackmate/detection/DetectionToTextConcurrentExample.java
+++ b/src/test/java/org/mastodon/trackmate/detection/DetectionToTextConcurrentExample.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorOp;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.scijava.Context;
 
 import bdv.spimdata.SpimDataMinimal;
@@ -150,7 +150,7 @@ public class DetectionToTextConcurrentExample
 		detectorSettings1.put( KEY_THRESHOLD, Double.valueOf( 100. ) );
 		detectorSettings1.put( KEY_MIN_TIMEPOINT, t1a );
 		detectorSettings1.put( KEY_MAX_TIMEPOINT, t1b );
-		final DetectorOp detector1 = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector1 = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings1 );
 
 		/*
@@ -159,7 +159,7 @@ public class DetectionToTextConcurrentExample
 		final Map< String, Object > detectorSettings2 = new HashMap<>( detectorSettings1 );
 		detectorSettings2.put( KEY_MIN_TIMEPOINT, t2a );
 		detectorSettings2.put( KEY_MAX_TIMEPOINT, t2b );
-		final DetectorOp detector2 = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector2 = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings2 );
 
 		/*

--- a/src/test/java/org/mastodon/trackmate/detection/DetectionToTextExample.java
+++ b/src/test/java/org/mastodon/trackmate/detection/DetectionToTextExample.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.mastodon.detection.DetectionCreatorFactory;
 import org.mastodon.detection.DetectionUtil;
 import org.mastodon.detection.DetectorOp;
-import org.mastodon.detection.DogDetectorOp;
+import org.mastodon.detection.DoGDetectorOp;
 import org.scijava.Context;
 
 import bdv.spimdata.SpimDataMinimal;
@@ -136,7 +136,7 @@ public class DetectionToTextExample
 		detectorSettings.put( KEY_MIN_TIMEPOINT, tps.get( 0 ).getId() );
 		detectorSettings.put( KEY_MAX_TIMEPOINT, tps.get( tps.size() - 1 ).getId() );
 
-		final DetectorOp detector = ( DetectorOp ) Inplaces.binary1( ops, DogDetectorOp.class,
+		final DetectorOp detector = ( DetectorOp ) Inplaces.binary1( ops, DoGDetectorOp.class,
 				detectionCreator, spimData, detectorSettings );
 		detector.mutate1( detectionCreator, spimData );
 

--- a/src/test/java/org/mastodon/trackmate/detection/TestDriveAddBehaviorFactories.java
+++ b/src/test/java/org/mastodon/trackmate/detection/TestDriveAddBehaviorFactories.java
@@ -1,0 +1,91 @@
+package org.mastodon.trackmate.detection;
+
+import static org.mastodon.detection.DetectorKeys.KEY_ADD_BEHAVIOR;
+import static org.mastodon.detection.DetectorKeys.KEY_RADIUS;
+import static org.mastodon.detection.DetectorKeys.KEY_THRESHOLD;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.detection.DetectionUtil;
+import org.mastodon.detection.mamut.AdvancedDoGDetectorMamut;
+import org.mastodon.detection.mamut.DoGDetectorMamut;
+import org.mastodon.detection.mamut.MamutDetectionCreatorFactories.DetectionBehavior;
+import org.mastodon.revised.mamut.MamutProject;
+import org.mastodon.revised.mamut.WindowManager;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.trackmate.Settings;
+import org.mastodon.trackmate.TrackMate;
+import org.scijava.Context;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import mpicbg.spim.data.SpimDataException;
+
+public class TestDriveAddBehaviorFactories
+{
+
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException, IOException, SpimDataException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		final Context context = new Context();
+		final WindowManager windowManager = new WindowManager( context );
+
+		final String bdvFile = "../TrackMate3/samples/mamutproject/datasethdf5.xml";
+		final MamutProject project = new MamutProject( null, new File( bdvFile ) );
+		windowManager.getProjectManager().open( project );
+
+		SpimDataMinimal sd = null;
+		try
+		{
+			sd = new XmlIoSpimDataMinimal().load( bdvFile );
+		}
+		catch ( final SpimDataException e )
+		{
+			e.printStackTrace();
+			return;
+		}
+		final SpimDataMinimal spimData = sd;
+
+		final Map< String, Object > ds = DetectionUtil.getDefaultDetectorSettingsMap();
+		ds.put( KEY_THRESHOLD, 20. );
+		ds.put( KEY_RADIUS, 5. );
+
+		final Settings settings = new Settings()
+				.spimData( spimData )
+				.detector( DoGDetectorMamut.class )
+				.detectorSettings( ds );
+
+		final Model model = windowManager.getAppModel().getModel();
+		final TrackMate trackmate = new TrackMate( settings, model );
+		trackmate.setContext( windowManager.getContext() );
+
+		if ( !trackmate.execDetection() )
+		{
+			System.err.println( "Detection failed:\n" + trackmate.getErrorMessage() );
+			return;
+		}
+		System.out.println( "First detection completed. Found " + model.getGraph().vertices().size() + " spots." );
+		windowManager.createBigDataViewer();
+
+		ds.put( KEY_ADD_BEHAVIOR, DetectionBehavior.DONTADD.name() );
+		ds.put( KEY_RADIUS, 12. );
+		ds.put( KEY_THRESHOLD, 300. );
+		settings.detector( AdvancedDoGDetectorMamut.class );
+		System.out.println( "Second detection round." );
+
+		if ( !trackmate.execDetection() )
+		{
+			System.err.println( "Detection failed:\n" + trackmate.getErrorMessage() );
+			return;
+		}
+		System.out.println( "Second detection completed. Found " + model.getGraph().vertices().size() + " spots." );
+	}
+}


### PR DESCRIPTION
This PR adds a semi-automatic tracker to the Mastodon tracking plugins. 
The tracker itself reproduces and enhances the feature we had in MaMuT and TrackMate, hopefully doing it better this time. 

The semi-auto tracker is a Mastodon standard plugin, that ships two commands:
- One command to launch semi-automatic tracking (default shortcut: Ctrl-T).
- The second command toggles the semi-auto tracker config page:
![capture](https://user-images.githubusercontent.com/3583203/38780550-a688105e-40d8-11e8-904f-62d776baede9.PNG)

The latter builds on the existing config page framework in Mastodon, with a settings manager, IO, etc... It is *not* integrated in the Mastodon application settings page collection, because the plugin framework does not let plugin add their own config page. This might be worth discussing. 

The semi-auto tracker takes the spots in the current selection, and process iteratively:
- Take the current source spot.
- Collect a small image neighborhood in the next frame (or previous frame if the tracker is configured to walk backward). Thanks to the BDV file format, this does not trigger a full image loading, but only the required blocks are read from disk. 
- Perform DoG detection in this neighborhood, above a specified quality threshold.
- Check if the best spot (highest quality) is withing a specified distance from the source spot. 
- If not, stop.
- If yes, check if there is an existing spot at this location.
  - If yes, link to it depending on a set of rules configurable by the user (for instance, you might to forbid linking to a spot that has existing incoming links for forward tracking, which would create a fusion).
  - If no, create a new spot there, and link the source to it.
- Make the target spot the source spot, and loop.

There is a couple of minor niceties aimed at simplifying semi-automatic work, such as 
- Triggering navigation events using the `GroupHandle` framework. It works for BDV views, but not for TrackScheme views - I don't know why yet. 
- Modifying the selection so that the last successfully tracked spots are set to be the selection, to resume semi-auto tracking quickly.

### TODOs before merge.
- [ ] Investigate why the navigation events are not caught by TrackScheme.
- [x] Make the `Track` button on the config page work.
- [ ] Discuss adding plugins settings page to the main Mastodon settings page.
- [x] Add a description for the two actions. 

### Possible future improvements.
- Right now, the detection and linking strategies are not configurable. Detection is DoG, and linking is made from the source spot location. One can envisage at least adding a Kalman tracker (with nearly constant velocity motion model) to predict the expected position of the source spot. and letting the user choose between diffusion and this motion model.
