### PR TITLE
Tweak detection wizard.

### DIFF
--- a/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/descriptors/BoundingBoxDescriptor.java
@@ -215,6 +215,8 @@ public class BoundingBoxDescriptor extends WizardPanelDescriptor
 		{
 			panel.useRoi.setSelected( null != settings.values.getDetectorSettings().get( KEY_ROI ) );
 		}
+		previousSetupID = setupID;
+		toggleBoundingBox( panel.useRoi.isSelected() );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
+++ b/src/main/java/org/mastodon/trackmate/ui/wizard/util/WizardUtils.java
@@ -238,6 +238,7 @@ public class WizardUtils
 			final ViewerPanelMamut viewer = bdv.getViewer();
 			InitializeViewerState.initTransform( viewer );
 			viewFrame = bdv.getViewerFrame();
+			viewFrame.setSettingsPanelVisible( false );
 
 			final BoundingSphereRadiusStatistics radiusStats = new BoundingSphereRadiusStatistics( model );
 			final OverlayGraphWrapper< Spot, Link > viewGraph = new OverlayGraphWrapper< >(


### PR DESCRIPTION
1. Hide empty toolbar in the detection preview windows.
![Screenshot-2019-03-26-at-17 52 32](https://user-images.githubusercontent.com/3583203/55063854-33183480-5079-11e9-825f-c5fd8f7ed04d.png)

2. Restore a previously defined ROI in the detection wizard.