### PR TITLE
Hopefully fix physical scaling.

### DIFF
--- a/src/main/java/org/mastodon/detection/DoGDetectorOp.java
+++ b/src/main/java/org/mastodon/detection/DoGDetectorOp.java
@@ -147,6 +147,7 @@ public class DoGDetectorOp
 			 */
 
 			final double[] calibration = DetectionUtil.getPhysicalCalibration( sources, tp, setup, level );
+			final double physicalSizeOfGlobalUnit = DetectionUtil.getPhysicalSizeOfGlobalUnit( sources, tp, setup );
 			final int stepsPerOctave = 4;
 			final double k = Math.pow( 2.0, 1.0 / stepsPerOctave );
 			final double sigma = radius / Math.sqrt( zeroMin.numDimensions() );
@@ -186,7 +187,7 @@ public class DoGDetectorOp
 					 */
 					p3d.setPosition( p );
 					transform.apply( p3d, sp );
-					detectionCreator.createDetection( pos, radius, normalizedValue );
+					detectionCreator.createDetection( pos, radius / physicalSizeOfGlobalUnit, normalizedValue );
 				}
 			}
 			finally


### PR DESCRIPTION
Added a function `getPhysicalSizeOfGlobalUnit()` that determines the size of
a unit in the global coordinate system. This works by taking the voxel
dimension of a given source (which specifies how big a voxel at level 0
of this source is in physical units). Then the transformation of level 0
of the source into the global coordinate system is applied to get the
global unit length. Technically, the voxel dimension and source transform
specified in the BDV XML may be inconsistent (for example, if the transform
contains shearing, or would make the global system non-isotropic). Not to
mention that different sources may specify mutually inconsistent information.
Therefore, some compromise needs to be made, and this compromise is (here
and in other places) to do the calculation with the pixel width (dimension
0) from the voxel dimensions of a specified setup.

This `physicalSizeOfGlobalUnit` needs to be considered when computing the
physical calibration of a particular resolution level of a particular
setup. It also needs to be taken into account when setting the radius of
a detected spot (which is specified in global units).